### PR TITLE
remove magic numbers with number of space dimensions semantic

### DIFF
--- a/doc/logs.md
+++ b/doc/logs.md
@@ -38,10 +38,15 @@ MB OOO.  No pair programming.
     @@
     @
     @ ---------->  x
-
-
-
 ```
+
+### Docs
+
+Notes on creating documentation:
+
+* `cargo doc --verbose`
+* [The rustdoc book](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html)
+
 
 ## 2024-08-07
 

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,27 +1,38 @@
-use automesh::Spn;
+// tests/io.rs
 
-#[test]
-#[should_panic(expected = "File type must be .npy")]
-fn from_npy_file_unreadable() {
-    // Guard against case where file exists, but it cannot be read,
-    // for example, by specifying a text file, `f.txt`, which is not
-    // `.npy` file.
-    let _spn = Spn::from_npy("tests/input/f.txt");
-}
+/// This module contains input/output (IO) integration tests for the `Spn`
+/// functionality.
+#[cfg(any(doc, test))]
+mod io_tests {
 
-#[test]
-#[should_panic(expected = "Could not find the .npy file")]
-fn from_npy_file_nonexistent() {
-    // Guard against case where file does not exist.
-    // Precondition: `f_file_nonexistent.npy` actually does not exist.
-    let _spn = Spn::from_npy("tests/input/f_file_nonexistent.npy");
-}
+    use automesh::Spn;
 
-#[test]
-#[should_panic(expected = "Could not open the .npy file")]
-fn from_npy_file_unopenable() {
-    // Guard against the case where the .npy file exists, but it
-    // cannot be opened. Here we have created an encrypted file
-    // contents contained `doc/encrypted.md`.
-    let _spn = Spn::from_npy("tests/input/encrypted.npy");
+    // TODO: What doesn't the triple forward slash (///) and the `pub` function make
+    // the documentation appear with the `cargo doc` command?
+
+    /// Guard against case where file exists, but it cannot be read,
+    /// for example, by specifying a text file, `f.txt`, which is not
+    /// `.npy` file.
+    #[test]
+    #[should_panic(expected = "File type must be .npy")]
+    pub fn from_npy_file_unreadable() {
+        let _spn = Spn::from_npy("tests/input/f.txt");
+    }
+
+    /// Guard against case where file does not exist.
+    /// Precondition: `f_file_nonexistent.npy` actually does not exist.
+    #[test]
+    #[should_panic(expected = "Could not find the .npy file")]
+    fn from_npy_file_nonexistent() {
+        let _spn = Spn::from_npy("tests/input/f_file_nonexistent.npy");
+    }
+
+    /// Guard against the case where the .npy file exists, but it
+    /// cannot be opened. Here we have created an encrypted file
+    /// contents contained `[doc/encrypted.md](../doc/encrypted.md)`.
+    #[test]
+    #[should_panic(expected = "Could not open the .npy file")]
+    fn from_npy_file_unopenable() {
+        let _spn = Spn::from_npy("tests/input/encrypted.npy");
+    }
 }

--- a/tests/spn.rs
+++ b/tests/spn.rs
@@ -3,12 +3,13 @@ use automesh::Spn;
 const NELZ: usize = 4;
 const NELY: usize = 5;
 const NELX: usize = 3;
-const NEL: [usize; 3] = [NELX, NELY, NELZ];
+const NSD: usize = 3;
+const NEL: [usize; NSD] = [NELX, NELY, NELZ];
 const NUM_ELEMENTS: usize = 39;
 const NUM_NODES: usize = 102;
 const NUM_NODES_ELEMENT: usize = 8;
-const SCALE: [f64; 3] = [1.2, 2.3, 0.4];
-const TRANSLATE: [f64; 3] = [-0.3, 1.1, 0.5];
+const SCALE: [f64; NSD] = [1.2, 2.3, 0.4];
+const TRANSLATE: [f64; NSD] = [-0.3, 1.1, 0.5];
 
 const GOLD_BLOCKS: [usize; NUM_ELEMENTS] = [1; NUM_ELEMENTS];
 const GOLD_CONNECTIVITY: [[usize; NUM_NODES_ELEMENT]; NUM_ELEMENTS] = [

--- a/tests/spn_single.rs
+++ b/tests/spn_single.rs
@@ -3,7 +3,7 @@ use automesh::Spn;
 const NELZ: usize = 1;
 const NELY: usize = 1;
 const NELX: usize = 1;
-const NSD: usize = 3; // number of space dimensions R3
+const NSD: usize = 3;
 const NEL: [usize; NSD] = [NELX, NELY, NELZ];
 const NUM_ELEMENTS: usize = 1;
 const NUM_NODES_ELEMENT: usize = 8;


### PR DESCRIPTION
## Goal

Remove magic number `3` in favor a semantic `NSD`, a T.J.R. Hughes abbreviation for *number of space dimensions*.
