### PR TITLE
Benchmarks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,46 @@ on:
 env:
   CARGO_TERM_COLOR: always
 jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: numpy
+        run: pip install numpy
+      - name: npy
+        run: |
+          python -c 'import numpy as np; np.save("benches/block_8.npy", np.ones((8, 8, 8)).astype("uint8"))'
+          python -c 'import numpy as np; np.save("benches/block_16.npy", np.ones((16, 16, 16)).astype("uint8"))'
+          python -c 'import numpy as np; np.save("benches/block_32.npy", np.ones((32, 32, 32)).astype("uint8"))'
+      - name: spn
+        run: |
+          cargo run -qr -- convert -i benches/block_8.npy -o benches/block_8.spn
+          cargo run -qr -- convert -i benches/block_16.npy -o benches/block_16.spn
+          cargo run -qr -- convert -i benches/block_32.npy -o benches/block_32.spn
+      - name: bench
+        run: rustup run nightly cargo bench
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: cleanup
+        run: rm -fr book/ sandbox/ tests/
+      - name: package
+        run: cargo package
+      - name: login
+        if: github.event_name == 'release'
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+      - name: publish
+        if: github.event_name == 'release'
+        run: cargo publish
   test:
     if: github.event_name != 'release'
     strategy:
@@ -36,18 +76,3 @@ jobs:
         run: cargo fmt --all -- --check
       - name: test
         run: cargo test --release
-  package:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: cleanup
-        run: rm -fr book/ sandbox/ tests/
-      - name: package
-        run: cargo package
-      - name: login
-        if: github.event_name == 'release'
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-      - name: publish
-        if: github.event_name == 'release'
-        run: cargo publish

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ Cargo.lock
 **__pycache__
 **.pytest_cache
 book/build/
+benches/*.npy
+benches/*.spn

--- a/benches/block.rs
+++ b/benches/block.rs
@@ -1,0 +1,64 @@
+#![feature(test)]
+
+extern crate test;
+use test::Bencher;
+
+use automesh::Voxels;
+
+const NEL: [usize; 3] = [10, 10, 10];
+const REMOVE: Option<Vec<u8>> = None;
+const SCALE: [f64; 3] = [1.0, 1.0, 1.0];
+const TRANSLATE: [f64; 3] = [0.0, 0.0, 0.0];
+
+// some seem to scale better than others
+// so need both small and large benches to show what
+
+#[bench]
+fn from_npy(bencher: &mut Bencher) {
+    bencher.iter(|| Voxels::from_npy("benches/block.npy"));
+}
+
+#[bench]
+fn from_npy_into_finite_elements(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        Voxels::from_npy("benches/block.npy")
+            .unwrap()
+            .into_finite_elements(REMOVE, &TRANSLATE, &SCALE)
+    });
+}
+
+#[bench]
+fn from_spn(bencher: &mut Bencher) {
+    bencher.iter(|| Voxels::from_spn("benches/block.spn", NEL));
+}
+
+#[bench]
+fn from_spn_into_finite_elements(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        Voxels::from_spn("benches/block.spn", NEL)
+            .unwrap()
+            .into_finite_elements(REMOVE, &TRANSLATE, &SCALE)
+    });
+}
+
+#[bench]
+fn write_npy(bencher: &mut Bencher) -> Result<(), String> {
+    let voxels = Voxels::from_spn("benches/block.spn", NEL)?;
+    bencher.iter(|| voxels.write_spn("target/block.npy"));
+    Ok(())
+}
+
+#[bench]
+fn write_spn(bencher: &mut Bencher) -> Result<(), String> {
+    let voxels = Voxels::from_spn("benches/block.spn", NEL)?;
+    bencher.iter(|| voxels.write_spn("target/block.spn"));
+    Ok(())
+}
+
+// #[bench]
+// fn from_npy(bencher: &mut Bencher) {
+//     let voxels = Voxels::from_npy("block.npy");
+//     bencher.iter(||
+//         voxels.
+//     );
+// }

--- a/benches/block.rs
+++ b/benches/block.rs
@@ -1,64 +1,106 @@
 #![feature(test)]
 
 extern crate test;
+use automesh::{Abaqus, Voxels};
 use test::Bencher;
 
-use automesh::Voxels;
-
-const NEL: [usize; 3] = [10, 10, 10];
 const REMOVE: Option<Vec<u8>> = None;
 const SCALE: [f64; 3] = [1.0, 1.0, 1.0];
 const TRANSLATE: [f64; 3] = [0.0, 0.0, 0.0];
 
-// some seem to scale better than others
-// so need both small and large benches to show what
-
-#[bench]
-fn from_npy(bencher: &mut Bencher) {
-    bencher.iter(|| Voxels::from_npy("benches/block.npy"));
+macro_rules! bench_block {
+    ($nel:expr) => {
+        const NEL: [usize; 3] = [$nel, $nel, $nel];
+        #[bench]
+        fn calculate_nodal_hierarchy(bencher: &mut Bencher) -> Result<(), String> {
+            let voxels = Voxels::from_spn(&format!("benches/block_{}.spn", $nel), NEL)?;
+            let mut fem = voxels.into_finite_elements(REMOVE, &SCALE, &TRANSLATE)?;
+            fem.calculate_node_element_connectivity()?;
+            fem.calculate_node_node_connectivity()?;
+            bencher.iter(|| fem.calculate_nodal_hierarchy().unwrap());
+            Ok(())
+        }
+        #[bench]
+        fn calculate_node_element_connectivity(bencher: &mut Bencher) -> Result<(), String> {
+            let voxels = Voxels::from_spn(&format!("benches/block_{}.spn", $nel), NEL)?;
+            let mut fem = voxels.into_finite_elements(REMOVE, &SCALE, &TRANSLATE)?;
+            bencher.iter(|| fem.calculate_node_element_connectivity().unwrap());
+            Ok(())
+        }
+        #[bench]
+        fn calculate_node_node_connectivity(bencher: &mut Bencher) -> Result<(), String> {
+            let voxels = Voxels::from_spn(&format!("benches/block_{}.spn", $nel), NEL)?;
+            let mut fem = voxels.into_finite_elements(REMOVE, &SCALE, &TRANSLATE)?;
+            fem.calculate_node_element_connectivity()?;
+            bencher.iter(|| fem.calculate_node_node_connectivity().unwrap());
+            Ok(())
+        }
+        #[bench]
+        fn from_npy(bencher: &mut Bencher) {
+            let npy = format!("benches/block_{}.npy", $nel);
+            bencher.iter(|| Voxels::from_npy(&npy).unwrap());
+        }
+        #[bench]
+        fn from_npy_into_finite_elements(bencher: &mut Bencher) {
+            let npy = format!("benches/block_{}.npy", $nel);
+            bencher.iter(|| {
+                Voxels::from_npy(&npy)
+                    .unwrap()
+                    .into_finite_elements(REMOVE, &SCALE, &TRANSLATE)
+                    .unwrap()
+            });
+        }
+        #[bench]
+        fn from_spn(bencher: &mut Bencher) {
+            let spn = format!("benches/block_{}.spn", $nel);
+            bencher.iter(|| Voxels::from_spn(&spn, NEL).unwrap());
+        }
+        #[bench]
+        fn from_spn_into_finite_elements(bencher: &mut Bencher) {
+            let spn = format!("benches/block_{}.spn", $nel);
+            bencher.iter(|| {
+                Voxels::from_spn(&spn, NEL)
+                    .unwrap()
+                    .into_finite_elements(REMOVE, &SCALE, &TRANSLATE)
+                    .unwrap()
+            });
+        }
+        #[bench]
+        fn write_inp(bencher: &mut Bencher) -> Result<(), String> {
+            let voxels = Voxels::from_spn(&format!("benches/block_{}.spn", $nel), NEL)?;
+            let fem = voxels.into_finite_elements(REMOVE, &SCALE, &TRANSLATE)?;
+            let inp = format!("target/block_{}.inp", $nel);
+            bencher.iter(|| fem.write_inp(&inp).unwrap());
+            Ok(())
+        }
+        #[bench]
+        fn write_npy(bencher: &mut Bencher) -> Result<(), String> {
+            let voxels = Voxels::from_spn(&format!("benches/block_{}.spn", $nel), NEL)?;
+            let npy = format!("target/block_{}.npy", $nel);
+            bencher.iter(|| voxels.write_spn(&npy).unwrap());
+            Ok(())
+        }
+        #[bench]
+        fn write_spn(bencher: &mut Bencher) -> Result<(), String> {
+            let voxels = Voxels::from_spn(&format!("benches/block_{}.spn", $nel), NEL)?;
+            let spn = format!("target/block_{}.spn", $nel);
+            bencher.iter(|| voxels.write_spn(&spn).unwrap());
+            Ok(())
+        }
+    };
 }
 
-#[bench]
-fn from_npy_into_finite_elements(bencher: &mut Bencher) {
-    bencher.iter(|| {
-        Voxels::from_npy("benches/block.npy")
-            .unwrap()
-            .into_finite_elements(REMOVE, &TRANSLATE, &SCALE)
-    });
+mod block_8 {
+    use super::*;
+    bench_block!(8);
 }
 
-#[bench]
-fn from_spn(bencher: &mut Bencher) {
-    bencher.iter(|| Voxels::from_spn("benches/block.spn", NEL));
+mod block_16 {
+    use super::*;
+    bench_block!(16);
 }
 
-#[bench]
-fn from_spn_into_finite_elements(bencher: &mut Bencher) {
-    bencher.iter(|| {
-        Voxels::from_spn("benches/block.spn", NEL)
-            .unwrap()
-            .into_finite_elements(REMOVE, &TRANSLATE, &SCALE)
-    });
+mod block_32 {
+    use super::*;
+    bench_block!(32);
 }
-
-#[bench]
-fn write_npy(bencher: &mut Bencher) -> Result<(), String> {
-    let voxels = Voxels::from_spn("benches/block.spn", NEL)?;
-    bencher.iter(|| voxels.write_spn("target/block.npy"));
-    Ok(())
-}
-
-#[bench]
-fn write_spn(bencher: &mut Bencher) -> Result<(), String> {
-    let voxels = Voxels::from_spn("benches/block.spn", NEL)?;
-    bencher.iter(|| voxels.write_spn("target/block.spn"));
-    Ok(())
-}
-
-// #[bench]
-// fn from_npy(bencher: &mut Bencher) {
-//     let voxels = Voxels::from_npy("block.npy");
-//     bencher.iter(||
-//         voxels.
-//     );
-// }

--- a/src/fem/test.rs
+++ b/src/fem/test.rs
@@ -23,20 +23,8 @@ fn test_finite_elements(
     finite_elements
         .calculate_node_element_connectivity()
         .unwrap();
-    assert_eq!(
-        finite_elements.calculate_node_element_connectivity(),
-        Err("Already calculated and set the node-to-element connectivity.")
-    );
     finite_elements.calculate_node_node_connectivity().unwrap();
-    assert_eq!(
-        finite_elements.calculate_node_node_connectivity(),
-        Err("Already calculated and set the node-to-node connectivity.")
-    );
     finite_elements.calculate_nodal_hierarchy().unwrap();
-    assert_eq!(
-        finite_elements.calculate_nodal_hierarchy(),
-        Err("Already calculated and set the nodal hierarchy.")
-    );
     assert_eq!(
         finite_elements.get_node_element_connectivity(),
         &node_element_connectivity_gold


### PR DESCRIPTION
@hovey some things this helped uncover:

- Reading .npy files scales nicely, reading .spn scales poorly.
- Writing either .npy or .spn files (converting) scales nicely.
  - They are bottlenecks for smaller meshes only.
- Writing .inp files scales poorly.
  - This is the primary bottleneck for any size mesh.
- Finite element operations scale with mesh size.
  - These are secondary bottlenecks mostly for larger meshes.
    - Converting voxels to finite elements.
    - Calculation steps necessary for hierarchical smoothing.
      - Calculating the node-to-node connectivity is mostly the problem.

<pre><font color="#F92AAD"><b>$ </b></font><font color="#005FD7">rustup</font> <font color="#00AFFF">run</font> <font color="#00AFFF">nightly</font> <font color="#00AFFF">cargo</font> <font color="#00AFFF"><u style="text-decoration-style:single">bench</u></font>
<font color="#54E484"><b>   Compiling</b></font> automesh v0.1.10 (/home/mrbuche/GitHub/autotwin/automesh)
<font color="#54E484"><b>    Finished</b></font> `bench` profile [optimized] target(s) in 1.86s
<font color="#54E484"><b>     Running</b></font> benches/block.rs (target/release/deps/block-508b41385b921cb1)

running 30 tests
test block_16::calculate_nodal_hierarchy           ... <font color="#58C7E2">bench</font>:      73,715.29 ns/iter (+/- 212.61)
test block_16::calculate_node_element_connectivity ... <font color="#58C7E2">bench</font>:     186,065.26 ns/iter (+/- 588.24)
test block_16::calculate_node_node_connectivity    ... <font color="#58C7E2">bench</font>:     814,697.98 ns/iter (+/- 5,958.84)
test block_16::from_npy                            ... <font color="#58C7E2">bench</font>:      48,558.99 ns/iter (+/- 1,127.39)
test block_16::from_npy_into_finite_elements       ... <font color="#58C7E2">bench</font>:     567,355.00 ns/iter (+/- 2,929.59)
test block_16::from_spn                            ... <font color="#58C7E2">bench</font>:     118,337.91 ns/iter (+/- 851.41)
test block_16::from_spn_into_finite_elements       ... <font color="#58C7E2">bench</font>:     638,296.30 ns/iter (+/- 3,888.54)
test block_16::write_inp                           ... <font color="#58C7E2">bench</font>:  10,913,198.80 ns/iter (+/- 879,832.40)
test block_16::write_npy                           ... <font color="#58C7E2">bench</font>:   4,003,488.55 ns/iter (+/- 60,869.15)
test block_16::write_spn                           ... <font color="#58C7E2">bench</font>:   3,999,986.52 ns/iter (+/- 320,672.40)
test block_32::calculate_nodal_hierarchy           ... <font color="#58C7E2">bench</font>:     537,637.60 ns/iter (+/- 6,226.12)
test block_32::calculate_node_element_connectivity ... <font color="#58C7E2">bench</font>:   1,446,038.00 ns/iter (+/- 7,467.55)
test block_32::calculate_node_node_connectivity    ... <font color="#58C7E2">bench</font>:   6,439,419.70 ns/iter (+/- 29,368.31)
test block_32::from_npy                            ... <font color="#58C7E2">bench</font>:      48,224.61 ns/iter (+/- 1,478.25)
test block_32::from_npy_into_finite_elements       ... <font color="#58C7E2">bench</font>:   4,073,872.00 ns/iter (+/- 93,986.68)
test block_32::from_spn                            ... <font color="#58C7E2">bench</font>:     712,413.40 ns/iter (+/- 9,291.14)
test block_32::from_spn_into_finite_elements       ... <font color="#58C7E2">bench</font>:   4,747,358.40 ns/iter (+/- 25,100.70)
test block_32::write_inp                           ... <font color="#58C7E2">bench</font>:  43,774,570.20 ns/iter (+/- 1,186,921.86)
test block_32::write_npy                           ... <font color="#58C7E2">bench</font>:   5,200,894.15 ns/iter (+/- 303,865.46)
test block_32::write_spn                           ... <font color="#58C7E2">bench</font>:   5,002,513.85 ns/iter (+/- 247,411.67)
test block_8::calculate_nodal_hierarchy            ... <font color="#58C7E2">bench</font>:       9,846.53 ns/iter (+/- 66.11)
test block_8::calculate_node_element_connectivity  ... <font color="#58C7E2">bench</font>:      23,707.41 ns/iter (+/- 61.63)
test block_8::calculate_node_node_connectivity     ... <font color="#58C7E2">bench</font>:      94,399.43 ns/iter (+/- 702.22)
test block_8::from_npy                             ... <font color="#58C7E2">bench</font>:      40,916.20 ns/iter (+/- 925.61)
test block_8::from_npy_into_finite_elements        ... <font color="#58C7E2">bench</font>:     106,736.08 ns/iter (+/- 1,230.82)
test block_8::from_spn                             ... <font color="#58C7E2">bench</font>:      35,991.09 ns/iter (+/- 1,685.65)
test block_8::from_spn_into_finite_elements        ... <font color="#58C7E2">bench</font>:     102,780.46 ns/iter (+/- 1,894.85)
test block_8::write_inp                            ... <font color="#58C7E2">bench</font>:   5,142,760.40 ns/iter (+/- 1,080,269.84)
test block_8::write_npy                            ... <font color="#58C7E2">bench</font>:   3,675,453.49 ns/iter (+/- 593,250.13)
test block_8::write_spn                            ... <font color="#58C7E2">bench</font>:   3,640,873.40 ns/iter (+/- 375,357.34)

test result: <font color="#54E484">ok</font>. 0 passed; 0 failed; 0 ignored; 30 measured; 0 filtered out; finished in 86.17s

</pre>