### PR TITLE
smoothing

### DIFF
--- a/src/fem/test.rs
+++ b/src/fem/test.rs
@@ -96,7 +96,7 @@ fn test_finite_elements(
             finite_elements.calculate_node_node_connectivity().unwrap();
             finite_elements.calculate_nodal_hierarchy().unwrap();
             finite_elements
-                .smooth(Smoothing::Laplacian(iterations, SMOOTHING_SCALE))
+                .smooth(Smoothing::Laplacian(iterations, SMOOTHING_SCALE), None)
                 .unwrap();
             let smoothed_nodal_coordinates = finite_elements.get_nodal_coordinates();
             assert!(smoothed_nodal_coordinates.len() == gold.len());
@@ -112,7 +112,25 @@ fn test_finite_elements(
                         )
                     }
                 });
-        })
+        });
+        let mut finite_elements = FiniteElements::from_data(
+            element_blocks.clone(),
+            element_node_connectivity.clone(),
+            nodal_coordinates.clone(),
+        );
+        finite_elements
+            .calculate_node_element_connectivity()
+            .unwrap();
+        finite_elements.calculate_node_node_connectivity().unwrap();
+        finite_elements.calculate_nodal_hierarchy().unwrap();
+        let prescribed_nodes = finite_elements.get_boundary_nodes().clone();
+        finite_elements
+            .smooth(
+                Smoothing::Laplacian(1, SMOOTHING_SCALE),
+                Some(&prescribed_nodes),
+            )
+            .unwrap();
+        assert_eq!(finite_elements.get_nodal_coordinates(), &nodal_coordinates)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,7 +386,7 @@ fn mesh(
                         // - calculate_nodal_hierarchy()
                         // - calculate_node_node_connectivity_boundary()
                         // - calculate_node_node_connectivity_interior()
-                        output_type.smooth(Smoothing::Laplacian(iterations, scale))?;
+                        output_type.smooth(Smoothing::Laplacian(iterations, scale), None)?;
                         if !quiet {
                             println!("        \x1b[1;92mDone\x1b[0m {:?}", time_smooth.elapsed());
                         }


### PR DESCRIPTION
feed in prescribed nodes, temporary API, zeroing entries of Laplacian seems most efficient strategy

<pre>
test block_16::smooth_free                               ... <font color="#58C7E2">bench</font>:     172,146.23 ns/iter (+/- 2,540.67)
test block_16::smooth_prescribed                         ... <font color="#58C7E2">bench</font>:     192,871.35 ns/iter (+/- 3,477.09)
test block_32::smooth_free                               ... <font color="#58C7E2">bench</font>:   1,125,261.30 ns/iter (+/- 27,825.47)
test block_32::smooth_prescribed                         ... <font color="#58C7E2">bench</font>:   1,422,452.80 ns/iter (+/- 26,699.89)
test block_8::smooth_free                                ... <font color="#58C7E2">bench</font>:      25,004.14 ns/iter (+/- 199.55)
test block_8::smooth_prescribed                          ... <font color="#58C7E2">bench</font>:      28,543.62 ns/iter (+/- 176.09)
</pre>