### PR TITLE
metrics

### DIFF
--- a/src/fem/mod.rs
+++ b/src/fem/mod.rs
@@ -1188,7 +1188,7 @@ fn calculate_minimum_scaled_jacobians(
                         _ => panic!(),
                     }
                     n = u.cross(&v);
-                    (&n * &w) / n.norm() / w.norm()
+                    (&n * &w) / u.norm() / v.norm() / w.norm()
                 })
                 .collect::<Vec<f64>>()
                 .into_iter()

--- a/src/fem/mod.rs
+++ b/src/fem/mod.rs
@@ -1198,7 +1198,7 @@ fn calculate_minimum_scaled_jacobians(
         .collect();
     #[cfg(feature = "profile")]
     println!(
-        "           \x1b[1;93m⤷ Minimum scaled Jacobians\x1b[0m {:?}",
+        "             \x1b[1;93mMinimum scaled Jacobians\x1b[0m {:?}",
         time.elapsed()
     );
     minimum_scaled_jacobians
@@ -1251,7 +1251,7 @@ fn calculate_maximum_skews(
         .collect();
     #[cfg(feature = "profile")]
     println!(
-        "           \x1b[1;93m⤷ Maximum skews\x1b[0m {:?}",
+        "             \x1b[1;93mMaximum skews\x1b[0m {:?}",
         time.elapsed()
     );
     maximum_skews

--- a/src/fem/mod.rs
+++ b/src/fem/mod.rs
@@ -1245,7 +1245,7 @@ fn calculate_maximum_skews(
                 .normalized();
             [(&x1 * &x2).abs(), (&x1 * &x3).abs(), (&x2 * &x3).abs()]
                 .into_iter()
-                .reduce(f64::min)
+                .reduce(f64::max)
                 .unwrap()
         })
         .collect();

--- a/src/fem/mod.rs
+++ b/src/fem/mod.rs
@@ -1091,7 +1091,7 @@ fn calculate_maximum_aspect_ratios(
                 .norm();
             [l1 / l2, l2 / l1, l1 / l3, l3 / l1, l2 / l3, l3 / l2]
                 .into_iter()
-                .reduce(f64::min)
+                .reduce(f64::max)
                 .unwrap()
         })
         .collect();


### PR DESCRIPTION
@hovey the skew was fixed by the min-max switch, the MSJ was actually a math error, I happened to look at https://docs.salome-platform.org/9/gui/SMESH/scaled_jacobian.html and was poisoned by it, the equations normalizing by |u x v| are wrong, it should be by |u| and |v| separately, which is consistent with Verdict though this page cites it