### PR TITLE
timing comparisons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ Cargo.lock
 **.pytest_cache
 book/build/
 benches/block/
+benches/compare/

--- a/benches/compare.py
+++ b/benches/compare.py
@@ -2,22 +2,41 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-numb = ()
-data = ()
+numb_a = ()
+data_a = ()
 
 with open('benches/compare/automesh_block.out', 'r') as file:
     for line in file:
         input = line.strip().split(sep=': ')
-        numb += (int(input[0])**3,)
+        numb_a += (int(input[0])**3,)
         count = 0
         sum = 0
         for entry in input[1].split():
             count += 1
             sum += float(entry)
-        data += (sum / count,)
+        data_a += (sum / count,)
 
+np.savetxt('benches/compare/automesh.csv', np.vstack((numb_a, data_a)).T)
 
-np.savetxt('benches/compare/compare.csv', np.vstack((numb, data)).T)
+numb_s = ()
+data_s = ()
 
-plt.plot(numb, data, numb, [data[0] + 185e-9 * (n - numb[0]) for n in numb])
+with open('benches/compare/sculpt_block.out', 'r') as file:
+    for line in file:
+        input = line.strip().split(sep=': ')
+        numb_s += (int(input[0])**3,)
+        count = 0
+        sum = 0
+        for entry in input[1].split():
+            count += 1
+            sum += float(entry)
+        data_s += (sum / count,)
+
+np.savetxt('benches/compare/sculpt.csv', np.vstack((numb_s, data_s)).T)
+
+plt.loglog(numb_a, data_a, label='automesh')
+plt.loglog(numb_s, data_s, label='SCULPT')
+plt.xlabel('Voxels')
+plt.ylabel('Time [seconds]')
+plt.legend()
 plt.show()

--- a/benches/compare.py
+++ b/benches/compare.py
@@ -1,0 +1,23 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+numb = ()
+data = ()
+
+with open('benches/compare/automesh_block.out', 'r') as file:
+    for line in file:
+        input = line.strip().split(sep=': ')
+        numb += (int(input[0])**3,)
+        count = 0
+        sum = 0
+        for entry in input[1].split():
+            count += 1
+            sum += float(entry)
+        data += (sum / count,)
+
+
+np.savetxt('benches/compare/compare.csv', np.vstack((numb, data)).T)
+
+plt.plot(numb, data, numb, [data[0] + 185e-9 * (n - numb[0]) for n in numb])
+plt.show()

--- a/benches/compare.py
+++ b/benches/compare.py
@@ -34,8 +34,30 @@ with open('benches/compare/sculpt_block.out', 'r') as file:
 
 np.savetxt('benches/compare/sculpt.csv', np.vstack((numb_s, data_s)).T)
 
+numb_p = ()
+numb_q = ()
+data_p = ()
+
+with open('benches/compare/automesh_remov.out', 'r') as file:
+    for line in file:
+        input = line.strip().split(sep=', ')
+        size = int(input[0])
+        real = input[1].split(sep=': ')[0]
+        numb_p += (int(size),)
+        numb_q += (int(real),)
+        count = 0
+        sum = 0
+        for entry in input[1].split(sep=': ')[1].split():
+            count += 1
+            sum += float(entry)
+        data_p += (sum / count,)
+
+np.savetxt('benches/compare/spheres.csv', np.vstack((numb_p, numb_q, data_p)).T)
+
 plt.loglog(numb_a, data_a, label='automesh')
+plt.loglog(numb_p, data_p, label='automesh (removal)')
 plt.loglog(numb_s, data_s, label='SCULPT')
+plt.loglog(numb_q, data_p, '--', color='tab:orange')
 plt.xlabel('Voxels')
 plt.ylabel('Time [seconds]')
 plt.legend()

--- a/benches/compare.py
+++ b/benches/compare.py
@@ -52,7 +52,8 @@ with open('benches/compare/automesh_remov.out', 'r') as file:
             sum += float(entry)
         data_p += (sum / count,)
 
-np.savetxt('benches/compare/spheres.csv', np.vstack((numb_p, numb_q, data_p)).T)
+np.savetxt('benches/compare/spheres.csv',
+           np.vstack((numb_p, numb_q, data_p)).T)
 
 plt.loglog(numb_a, data_a, label='automesh')
 plt.loglog(numb_p, data_p, label='automesh (removal)')

--- a/benches/compare.sh
+++ b/benches/compare.sh
@@ -19,6 +19,23 @@ do
   echo >> benches/compare/automesh_block.out
 done
 
+rm -f benches/compare/automesh_remov.out
+touch benches/compare/automesh_remov.out
+
+for NUM in `seq 4 19`
+do
+  size=$(python -c 'import numpy as np; print(len(np.load("book/analysis/sphere_with_shells/spheres_resolution_'${NUM}'.npy"))**3)')
+  real=$(python -c 'import numpy as np; print(int(np.sum(np.load("book/analysis/sphere_with_shells/spheres_resolution_'${NUM}'.npy") != 0)))')
+  echo -n "${size}, ${real}:" >> benches/compare/automesh_remov.out
+  for i in `seq 1 10`
+  do
+    start="$(date +'%s.%N')"
+    cargo run -qr -- mesh -i book/analysis/sphere_with_shells/spheres_resolution_${NUM}.npy -o benches/compare/compare.exo --remove 0 --quiet
+    echo -n " $(date +"%s.%N - ${start}" | bc)" >> benches/compare/automesh_remov.out
+  done
+  echo >> benches/compare/automesh_remov.out
+done
+
 rm -f benches/compare/sculpt_block.out
 touch benches/compare/sculpt_block.out
 

--- a/benches/compare.sh
+++ b/benches/compare.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 mkdir -p benches/block/ benches/compare/
-rm -f benches/compare/automesh_block.out benches/compare/sculpt_block.out
-touch benches/compare/automesh_block.out benches/compare/sculpt_block.out
+
+rm -f benches/compare/automesh_block.out
+touch benches/compare/automesh_block.out
 
 for NUM in 100 107 115 124 133 143 154 165 178 191 205 221 237 255 274 294 316 340 365 392 422 453 487
 do
@@ -16,6 +17,13 @@ do
     echo -n " $(date +"%s.%N - ${start}" | bc)" >> benches/compare/automesh_block.out
   done
   echo >> benches/compare/automesh_block.out
+done
+
+rm -f benches/compare/sculpt_block.out
+touch benches/compare/sculpt_block.out
+
+for NUM in 100 107 115 124 133 143 154 165 178 191 205 221 237 255 274 294 316 340 365 392
+do
   echo -n "${NUM}:" >> benches/compare/sculpt_block.out
   for i in `seq 1 10`
   do

--- a/benches/compare.sh
+++ b/benches/compare.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+mkdir -p benches/block/ benches/compare/
+rm -f benches/compare/automesh_block.out benches/compare/sculpt_block.out
+touch benches/compare/automesh_block.out benches/compare/sculpt_block.out
+
+for NUM in 100 107 115 124 133 143 154 165 178 191 205 221 237 255 274 294 316 340 365 392 422 453 487
+do
+  python benches/block.py --num ${NUM}
+  cargo run -qr -- convert -i benches/block/block_${NUM}.npy -o benches/block/block_${NUM}.spn --quiet
+  echo -n "${NUM}:" >> benches/compare/automesh_block.out
+  for i in `seq 1 10`
+  do
+    start="$(date +'%s.%N')"
+    cargo run -qr -- mesh -i benches/block/block_${NUM}.npy -o benches/compare/compare.exo --quiet
+    echo -n " $(date +"%s.%N - ${start}" | bc)" >> benches/compare/automesh_block.out
+  done
+  echo >> benches/compare/automesh_block.out
+  echo -n "${NUM}:" >> benches/compare/sculpt_block.out
+  for i in `seq 1 10`
+  do
+    start="$(date +'%s.%N')"
+    /opt/cubit/Cubit-17.02/bin/sculpt -isp benches/block/block_${NUM}.spn -x ${NUM} -y ${NUM} -z ${NUM} -str 3 -e benches/compare/compare.exo
+    echo -n " $(date +"%s.%N - ${start}" | bc)" >> benches/compare/sculpt_block.out
+  done
+  echo >> benches/compare/sculpt_block.out
+done


### PR DESCRIPTION
@hovey this has some timings compared to Sculpt for the upcoming presentation.

It turns out that `automesh` voxels->hexes has ideal O(N) scaling, meaning that the time it takes to mesh is proportional to the number of voxels, which means the rate is constant (average slope of 174.5 seconds per 1 billion voxels, which is about 5.7 million voxels per second, call it "five and a half" perhaps). Below is the data (blue) for number of voxels (x) vs. seconds (y) with a fit line (slope 174.5-9). This includes the I/O process.

![image](https://github.com/user-attachments/assets/9cd55cd4-4a7a-4eb5-aa66-ff3842b40d8b)

Data generated for the above is below (number of voxels vs. average time in seconds over 10 times) for a cube of one material.

```csv
1.000000000000000000e+06 2.403217182999999868e-01
1.225043000000000000e+06 2.762837030999999999e-01
1.520875000000000000e+06 3.233816666000000062e-01
1.906624000000000000e+06 3.906447749999999997e-01
2.352637000000000000e+06 4.685945823000000066e-01
2.924207000000000000e+06 5.691153707999999645e-01
3.652264000000000000e+06 6.898781083000000702e-01
4.492125000000000000e+06 8.458578253999998742e-01
5.639752000000000000e+06 1.035757290799999897e+00
6.967871000000000000e+06 1.273690306100000003e+00
8.615125000000000000e+06 1.550769071700000223e+00
1.079386100000000000e+07 1.938260087300000212e+00
1.331205300000000000e+07 2.338362317400000112e+00
1.658137500000000000e+07 2.921344691800000337e+00
2.057082400000000000e+07 3.545651624000000002e+00
2.541218400000000000e+07 4.427253978100000431e+00
3.155449600000000000e+07 5.443384358199999440e+00
3.930400000000000000e+07 6.702207261099999869e+00
4.862712500000000000e+07 8.451790017799998722e+00
6.023628800000000000e+07 1.031417554559999950e+01
7.515144800000000000e+07 1.317648003239999888e+01
9.295967700000000000e+07 1.707021161449999980e+01
1.155013030000000000e+08 2.136639796839999761e+01
```

Interested in how the rate changes with segmentation shape for constant numbers of voxels (extremes being x=y for z=1 or even x for y=z=1). Also how material removal speeds up the rate.

Working on Sculpt timings too. Much slower and my computer runs out of memory much sooner. Also has ideal O(N) scaling, just a much slower rate (0.1 million voxels per second) but we can always say how many times faster `automesh` is in this case (about 55x faster).

![image](https://github.com/user-attachments/assets/60ea0f14-5ae2-4cad-af4a-0e2096b8e82d)

```sh
/opt/cubit/Cubit-17.02/bin/sculpt -isp benches/block/block_${NUM}.spn -x ${NUM} -y ${NUM} -z ${NUM} -str 3 -e benches/compare/compare.exo
```

Data for SCULPT:

```csv
1.000000000000000000e+06 9.634390549900000877e+00
1.225043000000000000e+06 1.172998214459999922e+01
1.520875000000000000e+06 1.464097572550000237e+01
1.906624000000000000e+06 1.772968989929999850e+01
2.352637000000000000e+06 2.201075909169999889e+01
2.924207000000000000e+06 2.767168824099999824e+01
3.652264000000000000e+06 3.384805049630000440e+01
4.492125000000000000e+06 4.327494682950000282e+01
5.639752000000000000e+06 5.367644404320000007e+01
6.967871000000000000e+06 7.012962302069999510e+01
8.615125000000000000e+06 8.950217507550000562e+01
1.079386100000000000e+07 1.076788000511999996e+02
1.331205300000000000e+07 1.417179217032000054e+02
1.658137500000000000e+07 1.784800394180999774e+02
2.057082400000000000e+07 2.149033500231000176e+02
2.541218400000000000e+07 2.658127787129000126e+02
3.155449600000000000e+07 3.390398955293999848e+02
3.930400000000000000e+07 4.290817528341999605e+02
4.862712500000000000e+07 5.463870808151000347e+02
6.023628800000000000e+07 6.687284541565001064e+02
```

Non-log-log plot for fun:

![image](https://github.com/user-attachments/assets/515a1318-e3f0-4445-a546-7674c463189c)

I think the increasing speedups compared to Sculpt that we saw previously were due to increasing gains from material removal (the various resolution spheres). So then the story is that we are always much faster, but due to the material removal option, we become even faster and additional gain better scaling to become increasingly faster.

Yep, that is pretty much exactly the case. With removal (concentric sphere case, removing void), the rate increases from 5.5 to about 9.9, treating the original segmentation size as the number of voxels. If treating the number of voxels as the number not removed, the rate is about 5.1 which is about 93% the same. It almost returns to 5.5, meaning that the removal process is almost ideal in that it almost does not change the overall rate. Pretty awesome! Overall, `automesh` becomes incredibly fast compared to SCULPT when significant percentage of the segmentation is removed voxels, and the speedup can be roughly estimated by that percentage, i.e. 

net rate ~ (5.5 million voxels per second) / (fraction of retained voxels)

The rate in the spheres examples almost doubles since about half of the segmentation is void.

For example, if 90% of the voxels are removed, leaving 10% retained, `automesh` would be 550x faster than Sculpt.

![image](https://github.com/user-attachments/assets/3c935d2b-bfad-43b6-a267-a52256575f22)

```csv
1.728000000000000000e+06 8.819600000000000000e+05 2.390698671000000552e-01
2.985984000000000000e+06 1.530328000000000000e+06 3.670165891999999652e-01
4.741632000000000000e+06 2.437392000000000000e+06 5.628843816999999916e-01
7.077888000000000000e+06 3.646856000000000000e+06 8.036783936999999378e-01
1.007769600000000000e+07 5.202376000000000000e+06 1.124706139400000193e+00
1.382400000000000000e+07 7.145880000000000000e+06 1.494162844899999731e+00
1.839974400000000000e+07 9.523592000000000000e+06 1.951767540699999914e+00
2.388787200000000000e+07 1.237580800000000000e+07 2.535702913899999800e+00
3.037132800000000000e+07 1.574738400000000000e+07 3.113689215199999971e+00
3.793305600000000000e+07 1.968262400000000000e+07 3.893749364599999208e+00
4.665600000000000000e+07 2.422468000000000000e+07 4.869717950499999226e+00
5.662310400000000000e+07 2.941437600000000000e+07 5.879341042900000147e+00
6.791731200000000000e+07 3.530006400000000000e+07 6.940959474800000528e+00
8.062156800000000000e+07 4.191896000000000000e+07 8.229303044299999925e+00
9.481881600000000000e+07 4.931929600000000000e+07 9.733963018499999009e+00
1.105920000000000000e+08 5.754028800000000000e+07 1.113693403680000138e+01
```
