### PR TITLE
dev

### DIFF
--- a/.github/workflows/Bump.yml
+++ b/.github/workflows/Bump.yml
@@ -2,7 +2,8 @@ name: Bump
 on:
   release:
     types: published
-permissions: {}
+permissions:
+  contents: write
 jobs:
   Bump:
     runs-on: ubuntu-latest

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install
       run: pip install .[dev]
     - name: Style
-      run: pycodestyle --verbose .
+      run: pycodestyle --verbose tests
     - name: Test
       run: pytest --verbose
   Source:

--- a/.github/workflows/Rust.yml
+++ b/.github/workflows/Rust.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Cleanup
-        run: rm -fr book/ sandbox/ tests/
+        run: rm -fr benches/ book/ sandbox/ tests/
       - name: Package
         run: cargo package
       - name: Login

--- a/benches/compare.py
+++ b/benches/compare.py
@@ -56,6 +56,10 @@ np.savetxt(
     "benches/compare/spheres.csv", np.vstack((numb_p, numb_q, data_p)).T
 )
 
+print("automesh:", "{0:.2f}".format(np.mean(np.diff(numb_a) / np.diff(data_a)) / 1e6), "million voxels/second")
+print("automesh (removal):", "{0:.2f}".format(np.mean(np.diff(numb_p) / np.diff(data_p)) / 1e6), "million voxels/second")
+print("SCULPT:", "{0:.2f}".format(np.mean(np.diff(numb_s) / np.diff(data_s)) / 1e6), "million voxels/second")
+
 plt.loglog(numb_a, data_a, label="automesh")
 plt.loglog(numb_p, data_p, label="automesh (removal)")
 plt.loglog(numb_s, data_s, label="SCULPT")

--- a/benches/compare.py
+++ b/benches/compare.py
@@ -56,9 +56,15 @@ np.savetxt(
     "benches/compare/spheres.csv", np.vstack((numb_p, numb_q, data_p)).T
 )
 
-print("automesh:", "{0:.2f}".format(np.mean(np.diff(numb_a) / np.diff(data_a)) / 1e6), "million voxels/second")
-print("automesh (removal):", "{0:.2f}".format(np.mean(np.diff(numb_p) / np.diff(data_p)) / 1e6), "million voxels/second")
-print("SCULPT:", "{0:.2f}".format(np.mean(np.diff(numb_s) / np.diff(data_s)) / 1e6), "million voxels/second")
+print("automesh:",
+      "{0:.2f}".format(np.mean(np.diff(numb_a) / np.diff(data_a)) / 1e6),
+      "million voxels/second")
+print("automesh (removal):",
+      "{0:.2f}".format(np.mean(np.diff(numb_p) / np.diff(data_p)) / 1e6),
+      "million voxels/second")
+print("SCULPT:",
+      "{0:.2f}".format(np.mean(np.diff(numb_s) / np.diff(data_s)) / 1e6),
+      "million voxels/second")
 
 plt.loglog(numb_a, data_a, label="automesh")
 plt.loglog(numb_p, data_p, label="automesh (removal)")

--- a/src/fem/mod.rs
+++ b/src/fem/mod.rs
@@ -625,14 +625,13 @@ fn reorder_connectivity<const N: usize>(
             element_blocks
                 .iter()
                 .enumerate()
-                .filter(|&(_, &block)| &block == unique_block)
+                .filter(|&(_, block)| block == unique_block)
                 .flat_map(|(element, _)| {
                     element_node_connectivity[element]
                         .iter()
-                        .map(|entry| *entry as i32)
-                        .collect::<Vec<i32>>()
+                        .map(|&entry| entry as i32)
                 })
-                .collect::<Vec<i32>>()
+                .collect()
         })
         .collect()
 }
@@ -802,9 +801,10 @@ fn write_finite_elements_to_exodus<const N: usize>(
     );
     #[cfg(feature = "profile")]
     let time = Instant::now();
-    let xs: Vec<f64> = nodal_coordinates.iter().map(|coords| coords[0]).collect();
-    let ys: Vec<f64> = nodal_coordinates.iter().map(|coords| coords[1]).collect();
-    let zs: Vec<f64> = nodal_coordinates.iter().map(|coords| coords[2]).collect();
+    let (xs, (ys, zs)): (Vec<f64>, (Vec<f64>, Vec<f64>)) = nodal_coordinates
+        .iter()
+        .map(|coords| (coords[0], (coords[1], coords[2])))
+        .unzip();
     file.add_dimension("num_nodes", nodal_coordinates.len())?;
     file.add_variable::<f64>("coordx", &["num_nodes"])?
         .put_values(&xs, 0..)?;

--- a/src/voxel/mod.rs
+++ b/src/voxel/mod.rs
@@ -22,6 +22,8 @@ use std::{
     io::{BufRead, BufReader, BufWriter, Error, Write},
 };
 
+const NODE_NUMBERING_OFFSET_PLUS_ONE: usize = NODE_NUMBERING_OFFSET + 1;
+
 type InitialNodalCoordinates = Vec<Option<Coordinate>>;
 type VoxelDataFlattened = Blocks;
 type VoxelDataSized<const N: usize> = Vec<[usize; N]>;
@@ -400,21 +402,25 @@ fn initial_element_node_connectivity(
 ) -> Connectivity<HEX> {
     #[cfg(feature = "profile")]
     let time = Instant::now();
+    let nelxplus1_mul_nelyplus1 = nelxplus1 * nelyplus1;
     let element_node_connectivity: Connectivity<HEX> = filtered_voxel_data
         .iter()
         .map(|&[i, j, k]| {
             [
-                i + j * nelxplus1 + k * nelxplus1 * nelyplus1 + NODE_NUMBERING_OFFSET,
-                i + j * nelxplus1 + k * nelxplus1 * nelyplus1 + 1 + NODE_NUMBERING_OFFSET,
-                i + (j + 1) * nelxplus1 + k * nelxplus1 * nelyplus1 + 1 + NODE_NUMBERING_OFFSET,
-                i + (j + 1) * nelxplus1 + k * nelxplus1 * nelyplus1 + NODE_NUMBERING_OFFSET,
-                i + j * nelxplus1 + (k + 1) * nelxplus1 * nelyplus1 + NODE_NUMBERING_OFFSET,
-                i + j * nelxplus1 + (k + 1) * nelxplus1 * nelyplus1 + 1 + NODE_NUMBERING_OFFSET,
+                i + j * nelxplus1 + k * nelxplus1_mul_nelyplus1 + NODE_NUMBERING_OFFSET,
+                i + j * nelxplus1 + k * nelxplus1_mul_nelyplus1 + NODE_NUMBERING_OFFSET_PLUS_ONE,
                 i + (j + 1) * nelxplus1
-                    + (k + 1) * nelxplus1 * nelyplus1
-                    + 1
-                    + NODE_NUMBERING_OFFSET,
-                i + (j + 1) * nelxplus1 + (k + 1) * nelxplus1 * nelyplus1 + NODE_NUMBERING_OFFSET,
+                    + k * nelxplus1_mul_nelyplus1
+                    + NODE_NUMBERING_OFFSET_PLUS_ONE,
+                i + (j + 1) * nelxplus1 + k * nelxplus1_mul_nelyplus1 + NODE_NUMBERING_OFFSET,
+                i + j * nelxplus1 + (k + 1) * nelxplus1_mul_nelyplus1 + NODE_NUMBERING_OFFSET,
+                i + j * nelxplus1
+                    + (k + 1) * nelxplus1_mul_nelyplus1
+                    + NODE_NUMBERING_OFFSET_PLUS_ONE,
+                i + (j + 1) * nelxplus1
+                    + (k + 1) * nelxplus1_mul_nelyplus1
+                    + NODE_NUMBERING_OFFSET_PLUS_ONE,
+                i + (j + 1) * nelxplus1 + (k + 1) * nelxplus1_mul_nelyplus1 + NODE_NUMBERING_OFFSET,
             ]
         })
         .collect();


### PR DESCRIPTION
@hovey found a small but critical fix in the Exodus file writer (within the function reorder_connectivity which converts our connectivity structure into one for the NetCDF writer). So the "Element-to-node connectivity" part of the Writing section for Exodus files is now maybe 30% faster.

Changed our net rate for the blocks benchmark comparisons from 5.5 million voxels/second to just over 6.9 million voxels/second. So we are about 70x faster than SCULPT now in this case. It is about 50/50 for us on Meshing vs. Writing for Exodus files. For other files, Writing is of course the bottleneck for direct meshing.

Before:

<pre><font color="#58C7E0">cargo</font> <font color="#58C7E2">run</font> <font color="#58C7E2">-qr</font> <font color="#58C7E2">-F</font> <font color="#58C7E2">profile</font> <font color="#58C7E2">--</font> <font color="#58C7E2">mesh</font> <font color="#58C7E2">hex</font> <font color="#58C7E2">-i</font> <font color="#58C7E2"><u style="text-decoration-style:solid">benches/block/block_720.npy</u></font> <font color="#58C7E2">-o</font> <font color="#58C7E2">target/block_720.exo</font>
<font color="#EC00FF"><b>    automesh 0.3.3</b></font>
     <font color="#58C7E2"><b>Reading</b></font> benches/block/block_720.npy
        <font color="#54E484"><b>Done</b></font> 154.74406ms [1 materials, 373248000 voxels]
     <font color="#58C7E2"><b>Meshing</b></font> voxels into hexes
           <font color="#E0B401"><b>⤷ Removed voxels</b></font> 9.378739216s
             <font color="#E0B401"><b>Element-to-node connectivity</b></font> 7.285224451s
             <font color="#E0B401"><b>Nodal coordinates</b></font> 5.722238686s
             <font color="#E0B401"><b>Renumbered nodes</b></font> 4.117404616s
        <font color="#54E484"><b>Done</b></font> 27.499412654s [1 blocks, 373248000 elements, 374805361 nodes]
     <font color="#58C7E2"><b>Writing</b></font> target/block_720.exo
           <font color="#E0B401"><b>⤷ Element-to-node connectivity</b></font> 19.973423787s
             <font color="#E0B401"><b>Nodal coordinates</b></font> 9.127398218s
        <font color="#54E484"><b>Done</b></font> 31.592302436s
       <font color="#EC00FF"><b>Total</b></font> 59.882295263s</pre>

After:

<pre><font color="#58C7E0">cargo</font> <font color="#58C7E2">run</font> <font color="#58C7E2">-qr</font> <font color="#58C7E2">-F</font> <font color="#58C7E2">profile</font> <font color="#58C7E2">--</font> <font color="#58C7E2">mesh</font> <font color="#58C7E2">hex</font> <font color="#58C7E2">-i</font> <font color="#58C7E2"><u style="text-decoration-style:solid">benches/block/block_720.npy</u></font> <font color="#58C7E2">-o</font> <font color="#58C7E2"><u style="text-decoration-style:solid">target/block_720.exo</u></font>
<font color="#EC00FF"><b>    automesh 0.3.3</b></font>
     <font color="#58C7E2"><b>Reading</b></font> benches/block/block_720.npy
        <font color="#54E484"><b>Done</b></font> 145.875868ms [1 materials, 373248000 voxels]
     <font color="#58C7E2"><b>Meshing</b></font> voxels into hexes
           <font color="#E0B401"><b>⤷ Removed voxels</b></font> 8.780411386s
             <font color="#E0B401"><b>Element-to-node connectivity</b></font> 6.739418613s
             <font color="#E0B401"><b>Nodal coordinates</b></font> 5.657648441s
             <font color="#E0B401"><b>Renumbered nodes</b></font> 4.041100239s
        <font color="#54E484"><b>Done</b></font> 26.161402382s [1 blocks, 373248000 elements, 374805361 nodes]
     <font color="#58C7E2"><b>Writing</b></font> target/block_720.exo
           <font color="#E0B401"><b>⤷ Element-to-node connectivity</b></font> 12.143821757s
             <font color="#E0B401"><b>Nodal coordinates</b></font> 7.818196663s
        <font color="#54E484"><b>Done</b></font> 27.579682933s
       <font color="#EC00FF"><b>Total</b></font> 54.480233588s</pre>