### PR TITLE
tets

### DIFF
--- a/src/fem/mod.rs
+++ b/src/fem/mod.rs
@@ -72,6 +72,8 @@ pub trait FiniteElementMethods<const N: usize>
 where
     Self: FiniteElementSpecifics + Sized,
 {
+    /// Returns and moves the data associated with the finite elements.
+    fn data(self) -> (Blocks, Connectivity<N>, Coordinates);
     /// Constructs and returns a new finite elements type from data.
     fn from_data(
         element_blocks: Blocks,
@@ -142,6 +144,13 @@ impl<const N: usize> FiniteElementMethods<N> for FiniteElements<N>
 where
     Self: FiniteElementSpecifics + Sized,
 {
+    fn data(self) -> (Blocks, Connectivity<N>, Coordinates) {
+        (
+            self.element_blocks,
+            self.element_node_connectivity,
+            self.nodal_coordinates,
+        )
+    }
     fn from_data(
         element_blocks: Blocks,
         element_node_connectivity: Connectivity<N>,
@@ -758,6 +767,7 @@ fn write_finite_elements_to_exodus<const N: usize>(
             )?;
             match N {
                 HEX => connectivities.put_attribute("elem_type", "HEX8")?,
+                TET => connectivities.put_attribute("elem_type", "TET4")?,
                 TRI => connectivities.put_attribute("elem_type", "TRI3")?,
                 _ => panic!(),
             };

--- a/src/fem/py.rs
+++ b/src/fem/py.rs
@@ -20,6 +20,14 @@ pub struct HexahedralFiniteElements {
     nodal_coordinates: PyCoordinates,
 }
 
+/// The tetrahedral finite elements class.
+#[pyclass]
+pub struct TetrahedralFiniteElements {
+    element_blocks: Blocks,
+    element_node_connectivity: Connectivity<HEX>,
+    nodal_coordinates: PyCoordinates,
+}
+
 /// The triangular finite elements class.
 #[pyclass]
 pub struct TriangularFiniteElements {
@@ -44,6 +52,115 @@ impl HexahedralFiniteElements {
         }
     }
     /// Constructs and returns a new hexahedral finite elements class from an Abaqus file.
+    #[staticmethod]
+    pub fn from_inp(file_path: &str) -> Result<Self, PyIntermediateError> {
+        let (element_blocks, element_node_connectivity, nodal_coordinates) =
+            finite_element_data_from_inp(file_path)?;
+        Ok(Self::from_data(
+            element_blocks,
+            element_node_connectivity,
+            nodal_coordinates.as_foo(),
+        ))
+    }
+    /// Smooths the nodal coordinates according to the provided smoothing method.
+    #[pyo3(signature = (method="Taubin", hierarchical=false, iterations=10, pass_band=0.1, scale=0.6307))]
+    pub fn smooth(
+        &mut self,
+        method: &str,
+        hierarchical: bool,
+        iterations: usize,
+        pass_band: f64,
+        scale: f64,
+    ) -> Result<(), PyIntermediateError> {
+        let mut finite_elements = super::HexahedralFiniteElements::from_data(
+            self.element_blocks.clone(),
+            self.element_node_connectivity.clone(),
+            self.nodal_coordinates.as_foo(),
+        );
+        finite_elements.node_element_connectivity()?;
+        finite_elements.node_node_connectivity()?;
+        if hierarchical {
+            finite_elements.nodal_hierarchy()?;
+        }
+        finite_elements.nodal_influencers();
+        match method {
+            "Gauss" | "gauss" | "Gaussian" | "gaussian" | "Laplacian" | "Laplace" | "laplacian"
+            | "laplace" => {
+                finite_elements.smooth(Smoothing::Laplacian(iterations, scale))?;
+            }
+            "Taubin" | "taubin" => {
+                finite_elements.smooth(Smoothing::Taubin(iterations, pass_band, scale))?;
+            }
+            _ => return Err(format!("Invalid smoothing method {} specified.", method))?,
+        }
+        self.element_blocks = finite_elements.element_blocks;
+        self.element_node_connectivity = finite_elements.element_node_connectivity;
+        self.nodal_coordinates = finite_elements.nodal_coordinates.as_foo();
+        Ok(())
+    }
+    /// Writes the finite elements data to a new Exodus file.
+    pub fn write_exo(&self, file_path: &str) -> Result<(), PyIntermediateError> {
+        Ok(write_finite_elements_to_exodus(
+            file_path,
+            &self.element_blocks,
+            &self.element_node_connectivity,
+            &self.nodal_coordinates.as_foo(),
+        )?)
+    }
+    /// Writes the finite elements data to a new Abaqus file.
+    pub fn write_inp(&self, file_path: &str) -> Result<(), PyIntermediateError> {
+        Ok(write_finite_elements_to_abaqus(
+            file_path,
+            &self.element_blocks,
+            &self.element_node_connectivity,
+            &self.nodal_coordinates.as_foo(),
+        )?)
+    }
+    /// Writes the finite elements data to a new Mesh file.
+    pub fn write_mesh(&self, file_path: &str) -> Result<(), PyIntermediateError> {
+        Ok(write_finite_elements_to_mesh(
+            file_path,
+            &self.element_blocks,
+            &self.element_node_connectivity,
+            &self.nodal_coordinates.as_foo(),
+        )?)
+    }
+    /// Writes the finite elements quality metrics to a new file.
+    pub fn write_metrics(&self, file_path: &str) -> Result<(), PyIntermediateError> {
+        Ok(super::HexahedralFiniteElements::from_data(
+            self.element_blocks.clone(),
+            self.element_node_connectivity.clone(),
+            self.nodal_coordinates.as_foo(),
+        )
+        .write_metrics(file_path)?)
+    }
+    /// Writes the finite elements data to a new VTK file.
+    pub fn write_vtk(&self, file_path: &str) -> Result<(), PyIntermediateError> {
+        Ok(write_finite_elements_to_vtk(
+            file_path,
+            &self.element_blocks,
+            &self.element_node_connectivity,
+            &self.nodal_coordinates.as_foo(),
+        )?)
+    }
+}
+
+#[pymethods]
+impl TetrahedralFiniteElements {
+    /// Constructs and returns a new tetrahedral finite elements class from data.
+    #[new]
+    pub fn from_data(
+        element_blocks: Blocks,
+        element_node_connectivity: Connectivity<HEX>,
+        nodal_coordinates: PyCoordinates,
+    ) -> Self {
+        Self {
+            element_blocks,
+            element_node_connectivity,
+            nodal_coordinates,
+        }
+    }
+    /// Constructs and returns a new tetrahedral finite elements class from an Abaqus file.
     #[staticmethod]
     pub fn from_inp(file_path: &str) -> Result<Self, PyIntermediateError> {
         let (element_blocks, element_node_connectivity, nodal_coordinates) =

--- a/src/voxel/mod.rs
+++ b/src/voxel/mod.rs
@@ -7,6 +7,8 @@ pub mod test;
 #[cfg(feature = "profile")]
 use std::time::Instant;
 
+use crate::TetrahedralFiniteElements;
+
 use super::{
     fem::{
         Blocks, Connectivity, FiniteElementMethods, HexahedralFiniteElements, HEX,
@@ -318,7 +320,7 @@ pub struct Voxels {
 }
 
 impl Voxels {
-    /// Moves and returns the data associated with the voxels.
+    /// Returns and moves the data associated with the voxels.
     pub fn data(self) -> (VoxelData, Remove, Scale, Translate) {
         (self.data, self.remove, self.scale, self.translate)
     }
@@ -408,7 +410,7 @@ impl Voxels {
 }
 
 impl From<Voxels> for HexahedralFiniteElements {
-    fn from(voxels: Voxels) -> HexahedralFiniteElements {
+    fn from(voxels: Voxels) -> Self {
         let (element_blocks, element_node_connectivity, nodal_coordinates) =
             finite_element_data_from_data(
                 voxels.data,
@@ -417,6 +419,12 @@ impl From<Voxels> for HexahedralFiniteElements {
                 voxels.translate,
             );
         Self::from_data(element_blocks, element_node_connectivity, nodal_coordinates)
+    }
+}
+
+impl From<Voxels> for TetrahedralFiniteElements {
+    fn from(voxels: Voxels) -> Self {
+        HexahedralFiniteElements::from(voxels).into()
     }
 }
 

--- a/src/voxel/py.rs
+++ b/src/voxel/py.rs
@@ -1,6 +1,6 @@
 use super::{
     super::{
-        fem::py::HexahedralFiniteElements,
+        fem::py::{HexahedralFiniteElements, TetrahedralFiniteElements},
         py::{IntoFoo, PyIntermediateError},
         Blocks, NSD,
     },
@@ -40,7 +40,7 @@ impl Voxels {
             nodal_coordinates.as_foo(),
         ))
     }
-    /// Converts the voxels type into a finite elements type.
+    /// Converts the voxels type into hexahedral finite elements.
     #[pyo3(signature = (remove=[].to_vec(), scale=[1.0, 1.0, 1.0], translate=[0.0, 0.0, 0.0]))]
     pub fn as_finite_elements(
         &self,
@@ -56,6 +56,27 @@ impl Voxels {
                 translate.into(),
             );
         Ok(HexahedralFiniteElements::from_data(
+            element_blocks,
+            element_node_connectivity,
+            nodal_coordinates.as_foo(),
+        ))
+    }
+    /// Converts the voxels type into tetrahedral finite elements.
+    #[pyo3(signature = (remove=[].to_vec(), scale=[1.0, 1.0, 1.0], translate=[0.0, 0.0, 0.0]))]
+    pub fn as_tetrahedra(
+        &self,
+        remove: Blocks,
+        scale: [f64; NSD],
+        translate: [f64; NSD],
+    ) -> Result<TetrahedralFiniteElements, PyIntermediateError> {
+        let (element_blocks, element_node_connectivity, nodal_coordinates) =
+            finite_element_data_from_data(
+                self.data.clone(),
+                remove.into(),
+                scale.into(),
+                translate.into(),
+            );
+        Ok(TetrahedralFiniteElements::from_data(
             element_blocks,
             element_node_connectivity,
             nodal_coordinates.as_foo(),


### PR DESCRIPTION
@hovey getting started with tets with voxels->tets, the same template will be used for the simpler matching cases when adaptively tetmeshing the octree

based on 6 tets in this .jou file that have compatible faces
```
reset
bri x 1
move volume 1 x 0.5 y 0.5 z 0.5
create curve vertex 4 6 
create curve vertex 1 5 
create curve vertex 4 8  
create curve vertex 12 3  
create curve vertex 16 11  
create curve vertex 6 14  
merge all
partition create surface 3 curve 13
partition create surface 6  curve 14  
partition create surface 5  curve 16  
partition create surface 4  curve 15  
partition create surface 1  curve 17  
partition create surface 2  curve 18  
volume 1 scheme tetmesh
volume 1 size 123456
mesh surface all
mesh volume 1
block 1 add volume 1
```

checked with simple checks in Cubit (sometimes it renders it weird though...) and running tension in Sierra

quality is Ok to start (showing MSJ)

![Screenshot from 2025-05-09 16-03-31](https://github.com/user-attachments/assets/f5a39498-7395-4621-b38d-5409b3ee001b)

