### PR TITLE
adaptive tetmeshing start

### DIFF
--- a/.github/workflows/Rust.yml
+++ b/.github/workflows/Rust.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install
         run: cargo install cargo-llvm-cov
       - name: Coverage
-        run: rustup run nightly cargo llvm-cov --profile release --fail-under-functions 49 --fail-under-lines 65 --fail-under-regions 34
+        run: rustup run nightly cargo llvm-cov --profile release --fail-under-functions 59 --fail-under-lines 64 --fail-under-regions 55
   Package:
     runs-on: ubuntu-latest
     steps:

--- a/src/fem/tet/mod.rs
+++ b/src/fem/tet/mod.rs
@@ -11,7 +11,7 @@ pub const TET: usize = 4;
 /// The tetrahedral finite elements type.
 pub type TetrahedralFiniteElements = FiniteElements<TET>;
 
-const NUM_TETS_PER_HEX: usize = 6;
+pub const NUM_TETS_PER_HEX: usize = 6;
 
 impl FiniteElementSpecifics for TetrahedralFiniteElements {
     fn connected_nodes(node: &usize) -> Vec<usize> {

--- a/src/fem/tet/mod.rs
+++ b/src/fem/tet/mod.rs
@@ -1,7 +1,7 @@
 use crate::FiniteElementMethods;
 
 use super::{
-    FiniteElementSpecifics, FiniteElements, HexahedralFiniteElements, Metrics, Tessellation, HEX,
+    FiniteElementSpecifics, FiniteElements, HEX, HexahedralFiniteElements, Metrics, Tessellation,
 };
 use std::{io::Error as ErrorIO, iter::repeat_n};
 

--- a/src/fem/tet/mod.rs
+++ b/src/fem/tet/mod.rs
@@ -41,7 +41,7 @@ impl FiniteElementSpecifics for TetrahedralFiniteElements {
 }
 
 impl TetrahedralFiniteElements {
-    fn hex_to_tet(connectivity: &[usize; HEX]) -> [[usize; TET]; NUM_TETS_PER_HEX] {
+    pub fn hex_to_tet(connectivity: &[usize; HEX]) -> [[usize; TET]; NUM_TETS_PER_HEX] {
         [
             [
                 connectivity[0],

--- a/src/fem/tet/mod.rs
+++ b/src/fem/tet/mod.rs
@@ -90,10 +90,8 @@ impl From<HexahedralFiniteElements> for TetrahedralFiniteElements {
             .into_iter()
             .flat_map(|hex_block| repeat_n(hex_block, NUM_TETS_PER_HEX))
             .collect();
-        let element_node_connectivity = hex_connectivity
-            .iter()
-            .flat_map(|connectivity| Self::hex_to_tet(connectivity))
-            .collect();
+        let element_node_connectivity =
+            hex_connectivity.iter().flat_map(Self::hex_to_tet).collect();
         Self::from_data(blocks, element_node_connectivity, nodal_coordinates)
     }
 }

--- a/src/fem/tet/mod.rs
+++ b/src/fem/tet/mod.rs
@@ -1,7 +1,7 @@
 use crate::FiniteElementMethods;
 
 use super::{
-    FiniteElementSpecifics, FiniteElements, HexahedralFiniteElements, Metrics, Tessellation,
+    FiniteElementSpecifics, FiniteElements, HexahedralFiniteElements, Metrics, Tessellation, HEX,
 };
 use std::{io::Error as ErrorIO, iter::repeat_n};
 
@@ -40,6 +40,49 @@ impl FiniteElementSpecifics for TetrahedralFiniteElements {
     }
 }
 
+impl TetrahedralFiniteElements {
+    fn hex_to_tet(connectivity: &[usize; HEX]) -> [[usize; TET]; NUM_TETS_PER_HEX] {
+        [
+            [
+                connectivity[0],
+                connectivity[1],
+                connectivity[3],
+                connectivity[4],
+            ],
+            [
+                connectivity[4],
+                connectivity[5],
+                connectivity[1],
+                connectivity[2],
+            ],
+            [
+                connectivity[5],
+                connectivity[6],
+                connectivity[2],
+                connectivity[7],
+            ],
+            [
+                connectivity[2],
+                connectivity[3],
+                connectivity[4],
+                connectivity[7],
+            ],
+            [
+                connectivity[7],
+                connectivity[5],
+                connectivity[4],
+                connectivity[2],
+            ],
+            [
+                connectivity[1],
+                connectivity[2],
+                connectivity[3],
+                connectivity[4],
+            ],
+        ]
+    }
+}
+
 impl From<HexahedralFiniteElements> for TetrahedralFiniteElements {
     fn from(hexes: HexahedralFiniteElements) -> Self {
         let (hex_blocks, hex_connectivity, nodal_coordinates) = hexes.data();
@@ -49,46 +92,7 @@ impl From<HexahedralFiniteElements> for TetrahedralFiniteElements {
             .collect();
         let element_node_connectivity = hex_connectivity
             .iter()
-            .flat_map(|connectivity| {
-                [
-                    [
-                        connectivity[0],
-                        connectivity[1],
-                        connectivity[3],
-                        connectivity[4],
-                    ],
-                    [
-                        connectivity[4],
-                        connectivity[5],
-                        connectivity[1],
-                        connectivity[2],
-                    ],
-                    [
-                        connectivity[5],
-                        connectivity[6],
-                        connectivity[2],
-                        connectivity[7],
-                    ],
-                    [
-                        connectivity[2],
-                        connectivity[3],
-                        connectivity[4],
-                        connectivity[7],
-                    ],
-                    [
-                        connectivity[7],
-                        connectivity[5],
-                        connectivity[4],
-                        connectivity[2],
-                    ],
-                    [
-                        connectivity[1],
-                        connectivity[2],
-                        connectivity[3],
-                        connectivity[4],
-                    ],
-                ]
-            })
+            .flat_map(|connectivity| Self::hex_to_tet(connectivity))
             .collect();
         Self::from_data(blocks, element_node_connectivity, nodal_coordinates)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1361,7 +1361,9 @@ where
             }
             let mut output_type: TetrahedralFiniteElements = if adapt {
                 let mut tree = Octree::from(input_type);
-                let foo = 1; // CANT YOU DO TETMESHING WITH WEAK BALANCING???
+                println!(
+                    "             \x1b[1;91mNeed to try adaptive tetmeshing with weak balancing!\x1b[0m"
+                );
                 tree.balance(true);
                 tree.into()
             } else {
@@ -1589,6 +1591,9 @@ fn octree(
     pair: bool,
     strong: bool,
 ) -> Result<(), ErrorWrapper> {
+    let remove_temporary = remove
+        .clone()
+        .map(|removal| removal.iter().map(|&entry| entry as u8).collect());
     let scale_temporary = Scale::from([xscale, yscale, zscale]);
     let translate_temporary = Translate::from([xtranslate, ytranslate, ztranslate]);
     let scale = [xscale, yscale, zscale].into();
@@ -1619,7 +1624,8 @@ fn octree(
     }
     tree.prune();
     let output_extension = Path::new(&output).extension().and_then(|ext| ext.to_str());
-    let output_type = HexahedralFiniteElements::from(tree);
+    let output_type =
+        tree.octree_into_finite_elements(remove_temporary, scale_temporary, translate_temporary)?;
     if !quiet {
         let mut blocks = output_type.get_element_blocks().clone();
         let elements = blocks.len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,7 +290,7 @@ struct ConvertSegmentationArgs {
 enum MeshSubcommand {
     /// Creates an all-hexahedral mesh from a segmentation
     Hex(MeshHexArgs),
-    /// Creates an all-tetrahedrak mesh from a segmentation
+    /// Creates an all-tetrahedral mesh from a segmentation
     Tet(MeshTetArgs),
     /// Creates all-triangular isosurface(s) from a segmentation
     Tri(MeshTriArgs),
@@ -1359,7 +1359,13 @@ where
                 time = Instant::now();
                 mesh_print_info(MeshBasis::Voxels, &scale_temporary, &translate_temporary)
             }
-            let mut output_type: TetrahedralFiniteElements = input_type.into();
+            let mut output_type: TetrahedralFiniteElements = if dual {
+                let mut tree = Octree::from(input_type);
+                tree.balance(true); // CANT YOU DO TETMESHING WITH WEAK BALANCING???
+                tree.into()
+            } else {
+                input_type.into()
+            };
             if !quiet {
                 let mut blocks = output_type.get_element_blocks().clone();
                 let elements = blocks.len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,9 +376,9 @@ struct MeshHexArgs {
     #[arg(action, long, short)]
     quiet: bool,
 
-    /// Pass to mesh using dualization
+    /// Pass to mesh adaptively.
     #[arg(action, hide = true, long)]
-    dual: bool,
+    adapt: bool,
 }
 
 #[derive(clap::Args)]
@@ -461,9 +461,9 @@ struct MeshTetArgs {
     #[arg(action, long, short)]
     quiet: bool,
 
-    /// Pass to mesh using dualization
+    /// Pass to mesh adaptively
     #[arg(action, hide = true, long)]
-    dual: bool,
+    adapt: bool,
 }
 
 #[derive(clap::Args)]
@@ -546,9 +546,9 @@ struct MeshTriArgs {
     #[arg(action, long, short)]
     quiet: bool,
 
-    /// Pass to mesh using dualization
+    /// Pass to mesh adaptively
     #[arg(action, hide = true, long)]
-    dual: bool,
+    adapt: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -881,7 +881,7 @@ fn main() -> Result<(), ErrorWrapper> {
                     args.ztranslate,
                     args.metrics,
                     args.quiet,
-                    args.dual,
+                    args.adapt,
                 )
             }
             MeshSubcommand::Tet(args) => {
@@ -903,7 +903,7 @@ fn main() -> Result<(), ErrorWrapper> {
                     args.ztranslate,
                     args.metrics,
                     args.quiet,
-                    args.dual,
+                    args.adapt,
                 )
             }
             MeshSubcommand::Tri(args) => {
@@ -925,7 +925,7 @@ fn main() -> Result<(), ErrorWrapper> {
                     args.ztranslate,
                     args.metrics,
                     args.quiet,
-                    args.dual,
+                    args.adapt,
                 )
             }
         },
@@ -1244,7 +1244,7 @@ fn mesh<const N: usize, T>(
     ztranslate: f64,
     metrics: Option<String>,
     quiet: bool,
-    dual: bool,
+    adapt: bool,
 ) -> Result<(), ErrorWrapper>
 where
     T: FiniteElementMethods<N>,
@@ -1287,7 +1287,7 @@ where
                 time = Instant::now();
                 mesh_print_info(MeshBasis::Voxels, &scale_temporary, &translate_temporary)
             }
-            let mut output_type: HexahedralFiniteElements = if dual {
+            let mut output_type: HexahedralFiniteElements = if adapt {
                 let mut tree = Octree::from(input_type);
                 tree.balance(true);
                 tree.pair();
@@ -1359,9 +1359,10 @@ where
                 time = Instant::now();
                 mesh_print_info(MeshBasis::Voxels, &scale_temporary, &translate_temporary)
             }
-            let mut output_type: TetrahedralFiniteElements = if dual {
+            let mut output_type: TetrahedralFiniteElements = if adapt {
                 let mut tree = Octree::from(input_type);
-                tree.balance(true); // CANT YOU DO TETMESHING WITH WEAK BALANCING???
+                let foo = 1; // CANT YOU DO TETMESHING WITH WEAK BALANCING???
+                tree.balance(true);
                 tree.into()
             } else {
                 input_type.into()

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1437,7 +1437,33 @@ impl From<Octree> for TetrahedralFiniteElements {
         let mut element_node_connectivity = vec![];
         let element_blocks = vec![1; element_node_connectivity.len()];
         let mut nodal_coordinates = Coordinates::zero(0);
+        // let mut cells_nodes = vec![0; tree.len()];
+        // let mut node_index = 1;
+        // tree.iter().enumerate().for_each(|(cell_index, cell)| {
+        //     if cell.is_leaf() {
+        //         cells_nodes[cell_index] = node_index;
+        //         nodal_coordinates.append(&mut TensorRank1Vec::new(&[[
+        //             0.5 * (2 * cell.get_min_x() + cell.get_lngth()) as f64 * tree.scale.x()
+        //                 + tree.translate.x(),
+        //             0.5 * (2 * cell.get_min_y() + cell.get_lngth()) as f64 * tree.scale.y()
+        //                 + tree.translate.y(),
+        //             0.5 * (2 * cell.get_min_z() + cell.get_lngth()) as f64 * tree.scale.z()
+        //                 + tree.translate.z(),
+        //         ]]));
+        //         node_index += 1;
+        //     }
+        // });
+        //
+        // Can you place nodes at the 8 corners of every leaf?
+        // And getting that connectivity right from the start will help a ton.
+        // For example, the simple template mergedness will be set already.
+        //
+        // tree.iter().for_each(|cell| {
+        //     if cell.is_leaf() {
 
+        //     }
+        // });
+        
         let fem = TetrahedralFiniteElements::from_data(
             element_blocks,
             element_node_connectivity,
@@ -1904,11 +1930,7 @@ impl From<Octree> for HexahedralFiniteElements {
                         .for_each(|(face_index, face_cell)| {
                             if let Some(face_cell_index) = face_cell {
                                 if let Some(face_subcells) = tree[*face_cell_index].get_cells() {
-                                    if face_subcells
-                                        .iter()
-                                        .filter(|&&subcell| tree[subcell].is_leaf())
-                                        .count()
-                                        == NUM_OCTANTS
+                                    if tree.check_leaves(face_subcells)
                                     {
                                         match face_index {
                                             0 => {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -4,8 +4,8 @@ use std::time::Instant;
 use super::{
     Coordinate, Coordinates, NSD,
     fem::{
-        Blocks, FiniteElementMethods, HexahedralFiniteElements, TetrahedralFiniteElements, TriangularFiniteElements, HEX,
-        NODE_NUMBERING_OFFSET,
+        Blocks, FiniteElementMethods, HexahedralFiniteElements, TetrahedralFiniteElements,
+        TriangularFiniteElements, HEX, NODE_NUMBERING_OFFSET,
     },
     voxel::{Nel, Remove, Scale, Translate, VoxelData, Voxels},
 };
@@ -920,9 +920,7 @@ impl Tree for Octree {
         self.balance(true);
     }
     fn check_leaves(&self, cells: &[usize]) -> bool {
-        cells
-            .iter()
-            .all(|&subcell| self[subcell].is_leaf())
+        cells.iter().all(|&subcell| self[subcell].is_leaf())
     }
     fn clusters(&self, remove: Option<&Blocks>, supercells_opt: Option<&Supercells>) -> Clusters {
         #[cfg(feature = "profile")]
@@ -1463,7 +1461,7 @@ impl From<Octree> for TetrahedralFiniteElements {
 
         //     }
         // });
-        
+
         let fem = TetrahedralFiniteElements::from_data(
             element_blocks,
             element_node_connectivity,
@@ -1882,7 +1880,10 @@ impl From<Octree> for HexahedralFiniteElements {
         let mut nodal_coordinates = Coordinates::zero(0);
         let mut cells_nodes = vec![0; tree.len()];
         let mut node_index = 1;
-        tree.iter().enumerate().filter(|(_, cell)| cell.is_leaf()).for_each(|(cell_index, cell)| {
+        tree.iter()
+            .enumerate()
+            .filter(|(_, cell)| cell.is_leaf())
+            .for_each(|(cell_index, cell)| {
                 cells_nodes[cell_index] = node_index;
                 nodal_coordinates.append(&mut TensorRank1Vec::new(&[[
                     0.5 * (2 * cell.get_min_x() + cell.get_lngth()) as f64 * tree.scale.x()
@@ -1893,7 +1894,7 @@ impl From<Octree> for HexahedralFiniteElements {
                         + tree.translate.z(),
                 ]]));
                 node_index += 1;
-        });
+            });
         let mut connected_faces = [None; NUM_FACES];
         let mut d_01_subcells = None;
         let mut d_04_subcells = None;
@@ -1905,8 +1906,7 @@ impl From<Octree> for HexahedralFiniteElements {
         let mut face_0_faces = &[None; NUM_FACES];
         tree.iter().for_each(|cell| {
             if let Some(cell_subcells) = cell.get_cells() {
-                if tree.check_leaves(cell_subcells)
-                {
+                if tree.check_leaves(cell_subcells) {
                     element_node_connectivity.push([
                         cells_nodes[cell_subcells[0]],
                         cells_nodes[cell_subcells[1]],
@@ -1928,8 +1928,7 @@ impl From<Octree> for HexahedralFiniteElements {
                         .for_each(|(face_index, face_cell)| {
                             if let Some(face_cell_index) = face_cell {
                                 if let Some(face_subcells) = tree[*face_cell_index].get_cells() {
-                                    if tree.check_leaves(face_subcells)
-                                    {
+                                    if tree.check_leaves(face_subcells) {
                                         match face_index {
                                             0 => {
                                                 element_node_connectivity.push([
@@ -1986,8 +1985,7 @@ impl From<Octree> for HexahedralFiniteElements {
                             if let Some(diag_subcells) =
                                 tree[tree[*face_1].get_faces()[4].unwrap()].get_cells()
                             {
-                                if tree.check_leaves(diag_subcells)
-                                {
+                                if tree.check_leaves(diag_subcells) {
                                     d_14_subcells = Some(diag_subcells);
                                 }
                             }
@@ -1999,8 +1997,7 @@ impl From<Octree> for HexahedralFiniteElements {
                         if connected_faces[1].is_some() {
                             if let Some(diag_subcells) = tree[face_0_faces[1].unwrap()].get_cells()
                             {
-                                if tree.check_leaves(diag_subcells)
-                                {
+                                if tree.check_leaves(diag_subcells) {
                                     d_01_subcells = Some(diag_subcells);
                                 }
                             }
@@ -2008,16 +2005,14 @@ impl From<Octree> for HexahedralFiniteElements {
                         if connected_faces[4].is_some() {
                             if let Some(diag_subcells) = tree[face_0_faces[4].unwrap()].get_cells()
                             {
-                                if tree.check_leaves(diag_subcells)
-                                {
+                                if tree.check_leaves(diag_subcells) {
                                     d_04_subcells = Some(diag_subcells);
                                     if d_01_subcells.is_some() && d_01_subcells.is_some() {
                                         if let Some(diag_subcells_also) = tree
                                             [tree[face_0_faces[1].unwrap()].get_faces()[4].unwrap()]
                                         .get_cells()
                                         {
-                                            if tree.check_leaves(diag_subcells_also)
-                                            {
+                                            if tree.check_leaves(diag_subcells_also) {
                                                 d014_subcells = Some(diag_subcells_also)
                                             }
                                         }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1437,7 +1437,7 @@ impl From<Octree> for TetrahedralFiniteElements {
         let mut element_node_connectivity = vec![];
         let element_blocks = vec![1; element_node_connectivity.len()];
         let mut nodal_coordinates = Coordinates::zero(0);
-        
+
         let fem = TetrahedralFiniteElements::from_data(
             element_blocks,
             element_node_connectivity,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -6,8 +6,8 @@ use crate::Connectivity;
 use super::{
     Coordinate, Coordinates, NSD,
     fem::{
-        Blocks, FiniteElementMethods, HexahedralFiniteElements, TetrahedralFiniteElements,
-        TriangularFiniteElements, HEX, NODE_NUMBERING_OFFSET,
+        Blocks, FiniteElementMethods, HEX, HexahedralFiniteElements, NODE_NUMBERING_OFFSET,
+        TetrahedralFiniteElements, TriangularFiniteElements,
     },
     voxel::{Nel, Remove, Scale, Translate, VoxelData, Voxels},
 };
@@ -1544,7 +1544,11 @@ impl From<Octree> for TetrahedralFiniteElements {
                 nodal_coordinates[node - NODE_NUMBERING_OFFSET] = coordinates
             });
         println!("Blocks ({}) {:?}", element_blocks.len(), element_blocks);
-        println!("Connectivity ({}) {:?}", element_node_connectivity.len(), element_node_connectivity);
+        println!(
+            "Connectivity ({}) {:?}",
+            element_node_connectivity.len(),
+            element_node_connectivity
+        );
         let fem = Self::from_data(element_blocks, element_node_connectivity, nodal_coordinates);
         #[cfg(feature = "profile")]
         println!(

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1435,26 +1435,12 @@ impl From<Octree> for TetrahedralFiniteElements {
         let mut element_node_connectivity = vec![];
         let element_blocks = vec![1; element_node_connectivity.len()];
         let mut nodal_coordinates = Coordinates::zero(0);
-        // let mut cells_nodes = vec![0; tree.len()];
-        // let mut node_index = 1;
-        // tree.iter().enumerate().for_each(|(cell_index, cell)| {
-        //     if cell.is_leaf() {
-        //         cells_nodes[cell_index] = node_index;
-        //         nodal_coordinates.append(&mut TensorRank1Vec::new(&[[
-        //             0.5 * (2 * cell.get_min_x() + cell.get_lngth()) as f64 * tree.scale.x()
-        //                 + tree.translate.x(),
-        //             0.5 * (2 * cell.get_min_y() + cell.get_lngth()) as f64 * tree.scale.y()
-        //                 + tree.translate.y(),
-        //             0.5 * (2 * cell.get_min_z() + cell.get_lngth()) as f64 * tree.scale.z()
-        //                 + tree.translate.z(),
-        //         ]]));
-        //         node_index += 1;
-        //     }
-        // });
         //
         // Can you place nodes at the 8 corners of every leaf?
         // And getting that connectivity right from the start will help a ton.
         // For example, the simple template mergedness will be set already.
+        //
+        // Use a segmentation as the background, i.e., redudantly fill out coords by index (or the reverse) and push into nodal_coordinates afterwards.
         //
         // tree.iter().for_each(|cell| {
         //     if cell.is_leaf() {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1882,8 +1882,7 @@ impl From<Octree> for HexahedralFiniteElements {
         let mut nodal_coordinates = Coordinates::zero(0);
         let mut cells_nodes = vec![0; tree.len()];
         let mut node_index = 1;
-        tree.iter().enumerate().for_each(|(cell_index, cell)| {
-            if cell.is_leaf() {
+        tree.iter().enumerate().filter(|(_, cell)| cell.is_leaf()).for_each(|(cell_index, cell)| {
                 cells_nodes[cell_index] = node_index;
                 nodal_coordinates.append(&mut TensorRank1Vec::new(&[[
                     0.5 * (2 * cell.get_min_x() + cell.get_lngth()) as f64 * tree.scale.x()
@@ -1894,7 +1893,6 @@ impl From<Octree> for HexahedralFiniteElements {
                         + tree.translate.z(),
                 ]]));
                 node_index += 1;
-            }
         });
         let mut connected_faces = [None; NUM_FACES];
         let mut d_01_subcells = None;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -4,8 +4,8 @@ use std::time::Instant;
 use super::{
     Coordinate, Coordinates, NSD,
     fem::{
-        Blocks, FiniteElementMethods, HEX, HexahedralFiniteElements, NODE_NUMBERING_OFFSET,
-        TriangularFiniteElements,
+        Blocks, FiniteElementMethods, HexahedralFiniteElements, TetrahedralFiniteElements, TriangularFiniteElements, HEX,
+        NODE_NUMBERING_OFFSET,
     },
     voxel::{Nel, Remove, Scale, Translate, VoxelData, Voxels},
 };
@@ -123,6 +123,7 @@ type Supercells = Vec<Option<[usize; 2]>>;
 pub trait Tree {
     fn balance(&mut self, strong: bool);
     fn boundaries(&mut self);
+    fn check_leaves(&self, cells: &[usize]) -> bool;
     fn clusters(&self, remove: Option<&Blocks>, supercells: Option<&Supercells>) -> Clusters;
     fn defeature(&mut self, min_num_voxels: usize);
     fn nel(&self) -> Nel;
@@ -918,6 +919,11 @@ impl Tree for Octree {
         }
         self.balance(true);
     }
+    fn check_leaves(&self, cells: &[usize]) -> bool {
+        cells
+            .iter()
+            .all(|&subcell| self[subcell].is_leaf())
+    }
     fn clusters(&self, remove: Option<&Blocks>, supercells_opt: Option<&Supercells>) -> Clusters {
         #[cfg(feature = "profile")]
         let time = Instant::now();
@@ -1423,8 +1429,31 @@ impl Tree for Octree {
     }
 }
 
+impl From<Octree> for TetrahedralFiniteElements {
+    fn from(mut tree: Octree) -> Self {
+        #[cfg(feature = "profile")]
+        let time = Instant::now();
+        // let mut element_blocks = vec![];
+        let mut element_node_connectivity = vec![];
+        let element_blocks = vec![1; element_node_connectivity.len()];
+        let mut nodal_coordinates = Coordinates::zero(0);
+        
+        let fem = TetrahedralFiniteElements::from_data(
+            element_blocks,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        #[cfg(feature = "profile")]
+        println!(
+            "             \x1b[1;93m...foo?\x1b[0m {:?} ",
+            time.elapsed()
+        );
+        fem
+    }
+}
+
 impl From<Octree> for TriangularFiniteElements {
-    fn from(mut tree: Octree) -> TriangularFiniteElements {
+    fn from(mut tree: Octree) -> Self {
         let mut removed_data: Blocks = (&tree.remove).into();
         removed_data.push(PADDING);
         tree.boundaries();
@@ -1767,8 +1796,60 @@ impl From<Octree> for TriangularFiniteElements {
     }
 }
 
+fn invert_connectivity(faces_connectivity: &[[usize; 4]], num_nodes: usize) -> Vec<Vec<usize>> {
+    let mut node_face_connectivity = vec![vec![]; num_nodes];
+    faces_connectivity
+        .iter()
+        .enumerate()
+        .for_each(|(face, connectivity)| {
+            connectivity
+                .iter()
+                .for_each(|node| node_face_connectivity[node - NODE_NUMBERING_OFFSET].push(face))
+        });
+    node_face_connectivity
+}
+
+fn edges(faces_connectivity: &[[usize; 4]]) -> Edges {
+    let mut edges: Edges = faces_connectivity
+        .iter()
+        .flat_map(|connectivity| {
+            [
+                [connectivity[0], connectivity[1]],
+                [connectivity[1], connectivity[2]],
+                [connectivity[2], connectivity[3]],
+                [connectivity[3], connectivity[0]],
+            ]
+            .into_iter()
+        })
+        .collect();
+    edges.iter_mut().for_each(|edge| edge.sort());
+    edges.sort();
+    edges.dedup();
+    edges
+}
+
+fn non_manifold(faces_connectivity: &[[usize; 4]], node_face_connectivity: &[Vec<usize>]) -> Edges {
+    edges(faces_connectivity)
+        .iter()
+        .flat_map(|&edge| {
+            if node_face_connectivity[edge[0] - NODE_NUMBERING_OFFSET]
+                .iter()
+                .filter(|face_a| {
+                    node_face_connectivity[edge[1] - NODE_NUMBERING_OFFSET].contains(face_a)
+                })
+                .count()
+                == 4
+            {
+                Some(edge)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 impl From<Octree> for HexahedralFiniteElements {
-    fn from(tree: Octree) -> HexahedralFiniteElements {
+    fn from(tree: Octree) -> Self {
         #[cfg(feature = "profile")]
         let time = Instant::now();
         let mut element_node_connectivity = vec![];
@@ -1800,11 +1881,7 @@ impl From<Octree> for HexahedralFiniteElements {
         let mut face_0_faces = &[None; NUM_FACES];
         tree.iter().for_each(|cell| {
             if let Some(cell_subcells) = cell.get_cells() {
-                if cell_subcells
-                    .iter()
-                    .filter(|&&subcell| tree[subcell].is_leaf())
-                    .count()
-                    == NUM_OCTANTS
+                if tree.check_leaves(cell_subcells)
                 {
                     element_node_connectivity.push([
                         cells_nodes[cell_subcells[0]],
@@ -1889,11 +1966,7 @@ impl From<Octree> for HexahedralFiniteElements {
                             if let Some(diag_subcells) =
                                 tree[tree[*face_1].get_faces()[4].unwrap()].get_cells()
                             {
-                                if diag_subcells
-                                    .iter()
-                                    .filter(|&&subcell| tree[subcell].is_leaf())
-                                    .count()
-                                    == NUM_OCTANTS
+                                if tree.check_leaves(diag_subcells)
                                 {
                                     d_14_subcells = Some(diag_subcells);
                                 }
@@ -1906,11 +1979,7 @@ impl From<Octree> for HexahedralFiniteElements {
                         if connected_faces[1].is_some() {
                             if let Some(diag_subcells) = tree[face_0_faces[1].unwrap()].get_cells()
                             {
-                                if diag_subcells
-                                    .iter()
-                                    .filter(|&&subcell| tree[subcell].is_leaf())
-                                    .count()
-                                    == NUM_OCTANTS
+                                if tree.check_leaves(diag_subcells)
                                 {
                                     d_01_subcells = Some(diag_subcells);
                                 }
@@ -1919,25 +1988,17 @@ impl From<Octree> for HexahedralFiniteElements {
                         if connected_faces[4].is_some() {
                             if let Some(diag_subcells) = tree[face_0_faces[4].unwrap()].get_cells()
                             {
-                                if diag_subcells
-                                    .iter()
-                                    .filter(|&&subcell| tree[subcell].is_leaf())
-                                    .count()
-                                    == NUM_OCTANTS
+                                if tree.check_leaves(diag_subcells)
                                 {
                                     d_04_subcells = Some(diag_subcells);
                                     if d_01_subcells.is_some() && d_01_subcells.is_some() {
-                                        if let Some(diag_subcells) = tree
+                                        if let Some(diag_subcells_also) = tree
                                             [tree[face_0_faces[1].unwrap()].get_faces()[4].unwrap()]
                                         .get_cells()
                                         {
-                                            if diag_subcells
-                                                .iter()
-                                                .filter(|&&subcell| tree[subcell].is_leaf())
-                                                .count()
-                                                == NUM_OCTANTS
+                                            if tree.check_leaves(diag_subcells_also)
                                             {
-                                                d014_subcells = Some(diag_subcells)
+                                                d014_subcells = Some(diag_subcells_also)
                                             }
                                         }
                                     }
@@ -2003,61 +2064,9 @@ impl From<Octree> for HexahedralFiniteElements {
         );
         #[cfg(feature = "profile")]
         println!(
-            "           \x1b[1;93m  Dualization of primal\x1b[0m {:?} ",
+            "             \x1b[1;93mDualization of primal\x1b[0m {:?} ",
             time.elapsed()
         );
         fem
     }
-}
-
-fn invert_connectivity(faces_connectivity: &[[usize; 4]], num_nodes: usize) -> Vec<Vec<usize>> {
-    let mut node_face_connectivity = vec![vec![]; num_nodes];
-    faces_connectivity
-        .iter()
-        .enumerate()
-        .for_each(|(face, connectivity)| {
-            connectivity
-                .iter()
-                .for_each(|node| node_face_connectivity[node - NODE_NUMBERING_OFFSET].push(face))
-        });
-    node_face_connectivity
-}
-
-fn edges(faces_connectivity: &[[usize; 4]]) -> Edges {
-    let mut edges: Edges = faces_connectivity
-        .iter()
-        .flat_map(|connectivity| {
-            [
-                [connectivity[0], connectivity[1]],
-                [connectivity[1], connectivity[2]],
-                [connectivity[2], connectivity[3]],
-                [connectivity[3], connectivity[0]],
-            ]
-            .into_iter()
-        })
-        .collect();
-    edges.iter_mut().for_each(|edge| edge.sort());
-    edges.sort();
-    edges.dedup();
-    edges
-}
-
-fn non_manifold(faces_connectivity: &[[usize; 4]], node_face_connectivity: &[Vec<usize>]) -> Edges {
-    edges(faces_connectivity)
-        .iter()
-        .flat_map(|&edge| {
-            if node_face_connectivity[edge[0] - NODE_NUMBERING_OFFSET]
-                .iter()
-                .filter(|face_a| {
-                    node_face_connectivity[edge[1] - NODE_NUMBERING_OFFSET].contains(face_a)
-                })
-                .count()
-                == 4
-            {
-                Some(edge)
-            } else {
-                None
-            }
-        })
-        .collect()
 }

--- a/src/voxel/mod.rs
+++ b/src/voxel/mod.rs
@@ -346,40 +346,6 @@ impl Voxels {
             translate,
         })
     }
-    /// Constructs and returns a new voxels type from an Octree.
-    pub fn from_octree(nel: Nel, mut tree: Octree) -> Self {
-        let mut data = VoxelData::from(nel);
-        let mut length = 0;
-        let mut x = 0;
-        let mut y = 0;
-        let mut z = 0;
-        tree.prune();
-        #[cfg(feature = "profile")]
-        let time = Instant::now();
-        tree.iter().for_each(|cell| {
-            x = *cell.get_min_x() as usize;
-            y = *cell.get_min_y() as usize;
-            z = *cell.get_min_z() as usize;
-            length = *cell.get_lngth() as usize;
-            (0..length).for_each(|i| {
-                (0..length).for_each(|j| {
-                    (0..length).for_each(|k| data[[x + i, y + j, z + k]] = cell.get_block())
-                })
-            })
-        });
-        let voxels = Self {
-            data,
-            remove: Remove::default(),
-            scale: Scale::default(),
-            translate: Translate::default(),
-        };
-        #[cfg(feature = "profile")]
-        println!(
-            "             \x1b[1;93mOctree to voxels\x1b[0m {:?}",
-            time.elapsed()
-        );
-        voxels
-    }
     /// Constructs and returns a new voxels type from an SPN file.
     pub fn from_spn(
         file_path: &str,


### PR DESCRIPTION
octree into tets start by placing nodes at every corner of every leaf and making 6 tets out of every leaf that has face neighbors that are not smaller (could be same size or larger) using the direct voxel-to-tet template

also fixed dev option for octree visualization