### PR TITLE
dualization

### DIFF
--- a/benches/compare.sh
+++ b/benches/compare.sh
@@ -8,12 +8,12 @@ touch benches/compare/automesh_block.out
 for NUM in 100 107 115 124 133 143 154 165 178 191 205 221 237 255 274 294 316 340 365 392 422 453 487
 do
   python benches/block.py --num ${NUM}
-  cargo run -qr -- convert segmentation -i benches/block/block_${NUM}.npy -o benches/block/block_${NUM}.spn --quiet
+  RAYON_NUM_THREADS=1 cargo run -qr -- convert segmentation -i benches/block/block_${NUM}.npy -o benches/block/block_${NUM}.spn --quiet
   echo -n "${NUM}:" >> benches/compare/automesh_block.out
   for i in `seq 1 10`
   do
     start="$(date +'%s.%N')"
-    cargo run -qr -- mesh hex -i benches/block/block_${NUM}.npy -o benches/compare/compare.exo --quiet
+    RAYON_NUM_THREADS=1 cargo run -qr -- mesh hex -i benches/block/block_${NUM}.npy -o benches/compare/compare.exo --quiet
     echo -n " $(date +"%s.%N - ${start}" | bc)" >> benches/compare/automesh_block.out
   done
   echo >> benches/compare/automesh_block.out
@@ -30,7 +30,7 @@ do
   for i in `seq 1 10`
   do
     start="$(date +'%s.%N')"
-    cargo run -qr -- mesh hex -i book/analysis/sphere_with_shells/spheres_resolution_${NUM}.npy -o benches/compare/compare.exo --remove 0 --quiet
+    RAYON_NUM_THREADS=1 cargo run -qr -- mesh hex -i book/analysis/sphere_with_shells/spheres_resolution_${NUM}.npy -o benches/compare/compare.exo --remove 0 --quiet
     echo -n " $(date +"%s.%N - ${start}" | bc)" >> benches/compare/automesh_remov.out
   done
   echo >> benches/compare/automesh_remov.out

--- a/book/smoothing/noise_augmentation.py
+++ b/book/smoothing/noise_augmentation.py
@@ -37,10 +37,9 @@ def has_four_entries(string_in: str) -> bool:
     return len(string_in.split(",")) == 4
 
 
-with (
-    open(FILE_INPUT, "r", encoding="utf-8") as fin,
-    open(FILE_OUTPUT, "w", encoding="utf-8") as fout,
-):
+with open(FILE_INPUT, "r", encoding="utf-8") as fin, open(
+    FILE_OUTPUT, "w", encoding="utf-8"
+) as fout:
     for line in fin:
         # print(line)  # debugging
         if has_four_entries(line):

--- a/book/smoothing/smoothing.py
+++ b/book/smoothing/smoothing.py
@@ -220,20 +220,19 @@ def smoothing_neighbors(neighbors: Neighbors, node_hierarchy: NodeHierarchy):
         nei_new = ()
 
         # breakpoint()
-        match level:
-            case Hierarchy.INTERIOR:
-                # print("INTERIOR node")
-                nei_new = nei_old
-            case Hierarchy.BOUNDARY:
-                # print("BOUNDARY node")
-                for nn, li in zip(nei_old, levels):
-                    if li >= level.value:
-                        nei_new += (nn,)
-            case Hierarchy.PRESCRIBED:
-                # print("PRESCRIBED node")
-                nei_new = ()
-            case _:
-                raise ValueError("Hierarchy value must be in [0, 1, 2]")
+        if level == Hierarchy.INTERIOR:
+            # print("INTERIOR node")
+            nei_new = nei_old
+        elif level == Hierarchy.BOUNDARY:
+            # print("BOUNDARY node")
+            for nn, li in zip(nei_old, levels):
+                if li >= level.value:
+                    nei_new += (nn,)
+        elif level == Hierarchy.PRESCRIBED:
+            # print("PRESCRIBED node")
+            nei_new = ()
+        else:
+            raise ValueError("Hierarchy value must be in [0, 1, 2]")
 
         neighbors_new += (nei_new,)
 

--- a/src/fem/hex/mod.rs
+++ b/src/fem/hex/mod.rs
@@ -5,8 +5,8 @@ pub mod test;
 use std::time::Instant;
 
 use super::{
-    FiniteElementMethods, FiniteElementSpecifics, FiniteElements, Metrics, NODE_NUMBERING_OFFSET,
-    Tessellation, Vector,
+    Connectivity, FiniteElementMethods, FiniteElementSpecifics, FiniteElements, Metrics,
+    NODE_NUMBERING_OFFSET, Tessellation, Vector,
 };
 use conspire::math::{Tensor, TensorArray};
 use ndarray::{Array2, s};
@@ -19,6 +19,9 @@ use std::{
 
 /// The number of nodes in a hexahedral finite element.
 pub const HEX: usize = 8;
+
+/// The element-to-node connectivity for hexahedral finite elements.
+pub type HexConnectivity = Connectivity<HEX>;
 
 /// The hexahedral finite elements type.
 pub type HexahedralFiniteElements = FiniteElements<HEX>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use fem::{
     TetrahedralFiniteElements, TriangularFiniteElements,
 };
 pub use tessellation::Tessellation;
-pub use tree::{Octree, Tree};
+pub use tree::Octree;
 pub use voxel::{Extraction, Nel, Remove, Scale, Translate, VoxelData, Voxels};
 
 use conspire::math::{TensorRank1, TensorRank1Vec};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1949,20 +1949,17 @@ where
         ))?,
     };
     if !quiet {
-        print!(
-            "\x1b[0m\n        \x1b[1;92mDone\x1b[0m {:?}",
-            time.elapsed()
-        );
         match &result {
             InputTypes::Npy(voxels) | InputTypes::Spn(voxels) => {
-                let data =  voxels.get_data();
-                let mut materials = vec![];
-                data.iter().for_each(|&voxel|
-                    if !materials.contains(&voxel) {
-                        materials.push(voxel)
-                    }
+                let data = voxels.get_data();
+                let mut materials = vec![false; u8::MAX as usize];
+                data.iter()
+                    .for_each(|&voxel| materials[voxel as usize] = true);
+                let voxels = data.iter().count();
+                print!(
+                    "\x1b[0m\n        \x1b[1;92mDone\x1b[0m {:?}",
+                    time.elapsed()
                 );
-                let voxels = data.len();
                 println!(
                     " \x1b[2m[{} materials, {} voxels]\x1b[0m",
                     materials.len(),
@@ -1970,7 +1967,10 @@ where
                 );
             }
             _ => {
-                println!();
+                println!(
+                    "\x1b[0m\n        \x1b[1;92mDone\x1b[0m {:?}",
+                    time.elapsed()
+                );
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1955,19 +1955,19 @@ where
         );
         match &result {
             InputTypes::Npy(voxels) | InputTypes::Spn(voxels) => {
-                let mut materials: Blocks = voxels.get_data().iter().copied().collect();
-                let voxels = materials.len();
+                let data =  voxels.get_data();
+                let mut materials = vec![];
+                data.iter().for_each(|&voxel|
+                    if !materials.contains(&voxel) {
+                        materials.push(voxel)
+                    }
+                );
+                let voxels = data.len();
                 println!(
-                    " \x1b[2m[{} voxels]\x1b[0m",
+                    " \x1b[2m[{} materials, {} voxels]\x1b[0m",
+                    materials.len(),
                     voxels
                 );
-                // materials.sort();
-                // materials.dedup();
-                // println!(
-                //     " \x1b[2m[{} materials, {} voxels]\x1b[0m",
-                //     materials.len(),
-                //     voxels
-                // );
             }
             _ => {
                 println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use automesh::{
     Blocks, Extraction, FiniteElementMethods, FiniteElementSpecifics, HEX,
     HexahedralFiniteElements, Nel, Octree, Remove, Scale, Smoothing, TET, TRI, Tessellation,
-    TetrahedralFiniteElements, Translate, Tree, TriangularFiniteElements, Voxels,
+    TetrahedralFiniteElements, Translate, TriangularFiniteElements, Voxels,
 };
 use clap::{Parser, Subcommand};
 use conspire::math::TensorVec;
@@ -1957,13 +1957,17 @@ where
             InputTypes::Npy(voxels) | InputTypes::Spn(voxels) => {
                 let mut materials: Blocks = voxels.get_data().iter().copied().collect();
                 let voxels = materials.len();
-                materials.sort();
-                materials.dedup();
                 println!(
-                    " \x1b[2m[{} materials, {} voxels]\x1b[0m",
-                    materials.len(),
+                    " \x1b[2m[{} voxels]\x1b[0m",
                     voxels
                 );
+                // materials.sort();
+                // materials.dedup();
+                // println!(
+                //     " \x1b[2m[{} materials, {} voxels]\x1b[0m",
+                //     materials.len(),
+                //     voxels
+                // );
             }
             _ => {
                 println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use automesh::{
-    Extraction, FiniteElementMethods, FiniteElementSpecifics, HEX,
-    HexahedralFiniteElements, Nel, Octree, Remove, Scale, Smoothing, TET, TRI, Tessellation,
-    TetrahedralFiniteElements, Translate, TriangularFiniteElements, Voxels,
+    Extraction, FiniteElementMethods, FiniteElementSpecifics, HEX, HexahedralFiniteElements, Nel,
+    Octree, Remove, Scale, Smoothing, TET, TRI, Tessellation, TetrahedralFiniteElements, Translate,
+    TriangularFiniteElements, Voxels,
 };
 use clap::{Parser, Subcommand};
 use conspire::math::TensorVec;
@@ -1955,15 +1955,15 @@ where
                 let mut materials = vec![false; u8::MAX as usize];
                 data.iter()
                     .for_each(|&voxel| materials[voxel as usize] = true);
-                let voxels = data.iter().count();
+                let num_voxels = data.iter().count();
+                let num_materials = materials.iter().filter(|&&entry| entry).count();
                 print!(
                     "\x1b[0m\n        \x1b[1;92mDone\x1b[0m {:?}",
                     time.elapsed()
                 );
                 println!(
                     " \x1b[2m[{} materials, {} voxels]\x1b[0m",
-                    materials.len(),
-                    voxels
+                    num_materials, num_voxels
                 );
             }
             _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use automesh::{
-    Blocks, Extraction, FiniteElementMethods, FiniteElementSpecifics, HEX,
+    Extraction, FiniteElementMethods, FiniteElementSpecifics, HEX,
     HexahedralFiniteElements, Nel, Octree, Remove, Scale, Smoothing, TET, TRI, Tessellation,
     TetrahedralFiniteElements, Translate, TriangularFiniteElements, Voxels,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1387,8 +1387,7 @@ where
                     mesh_print_info(MeshBasis::Voxels, &scale_temporary, &translate_temporary)
                 }
                 let mut tree = Octree::from(input_type);
-                tree.balance(true);
-                tree.pair();
+                tree.balance_and_pair(true);
                 tree.into()
             } else {
                 if !quiet {
@@ -1725,7 +1724,9 @@ fn octree(
     let mut tree = Octree::from(input_type);
     tree.balance(strong);
     if pair {
-        tree.pair();
+        tree.balance_and_pair(true);
+    } else {
+        tree.balance(strong);
     }
     tree.prune();
     let output_extension = Path::new(&output).extension().and_then(|ext| ext.to_str());

--- a/src/tree/hex/edge_template_1/mod.rs
+++ b/src/tree/hex/edge_template_1/mod.rs
@@ -1,0 +1,289 @@
+use super::super::{Coordinates, HexConnectivity, NODE_NUMBERING_OFFSET, NUM_OCTANTS, NodeMap, Octree};
+use conspire::math::{TensorVec, tensor_rank_1};
+
+pub fn apply(
+    cells_nodes: &Vec<usize>,
+    nodes_map: &mut NodeMap,
+    node_index: &mut usize,
+    tree: &Octree,
+    element_node_connectivity: &mut HexConnectivity,
+    nodal_coordinates: &mut Coordinates,
+) {
+    tree.iter()
+        .filter_map(|cell| tree.cell_contains_leaves(cell))
+        .for_each(|(cell_subcells, _)| {
+            let subcell_3_faces = tree[cell_subcells[3]].get_faces();
+            if let Some(subcell_3_face_1) = subcell_3_faces[1] {
+                if let Some(subcell_3_face_2) = subcell_3_faces[2] {
+                    if let Some((subcell_3_face_1_subcells, _)) =
+                        tree.cell_contains_leaves(&tree[subcell_3_face_1])
+                    {
+                        if let Some((subcell_3_face_2_subcells, _)) =
+                            tree.cell_contains_leaves(&tree[subcell_3_face_2])
+                        {
+                            if let Some(diagonal_1) =
+                                tree[subcell_3_face_1_subcells[2]].get_faces()[2]
+                            {
+                                if let Some(subdiagonal_1) =
+                                    tree[subcell_3_face_1_subcells[6]].get_faces()[2]
+                                {
+                                    let subcell_7_faces = tree[cell_subcells[7]].get_faces();
+                                    if let Some(subcell_7_face_1) = subcell_7_faces[1] {
+                                        if let Some(subcell_7_face_2) = subcell_7_faces[2] {
+                                            if let Some((subcell_7_face_1_subcells, _)) =
+                                                tree.cell_contains_leaves(&tree[subcell_7_face_1])
+                                            {
+                                                if let Some((subcell_7_face_2_subcells, _)) = tree
+                                                    .cell_contains_leaves(&tree[subcell_7_face_2])
+                                                {
+                                                    if let Some(diagonal_2) = tree
+                                                        [subcell_7_face_1_subcells[6]]
+                                                        .get_faces()[2]
+                                                    {
+                                                        if let Some(subdiagonal_2) = tree
+                                                            [subcell_7_face_1_subcells[2]]
+                                                            .get_faces()[2]
+                                                        {
+                                                            let lngth = *tree
+                                                                [subcell_3_face_1_subcells[6]]
+                                                                .get_lngth()
+                                                                as f64;
+                                                            let bar = tensor_rank_1([
+                                                                -2.0 * lngth,
+                                                                0.0,
+                                                                0.0,
+                                                            ]);
+                                                            nodal_coordinates.push(
+                                                                &nodal_coordinates[cells_nodes
+                                                                    [subcell_3_face_1_subcells[6]]]
+                                                                    + bar.clone(),
+                                                            );
+                                                            nodal_coordinates.push(
+                                                                &nodal_coordinates[cells_nodes
+                                                                    [subcell_7_face_1_subcells[2]]]
+                                                                    + bar.clone(),
+                                                            );
+                                                            nodes_map.insert(
+                                                                (
+                                                                    (2.0 * nodal_coordinates[*node_index
+                                                                        - NODE_NUMBERING_OFFSET][0])
+                                                                        as usize,
+                                                                    (2.0 * nodal_coordinates[*node_index
+                                                                        - NODE_NUMBERING_OFFSET][1])
+                                                                        as usize,
+                                                                    (2.0 * nodal_coordinates[*node_index
+                                                                        - NODE_NUMBERING_OFFSET][2])
+                                                                        as usize,
+                                                                ),
+                                                                *node_index,
+                                                            );
+                                                            nodes_map.insert(
+                                                                (
+                                                                    (2.0 * nodal_coordinates[*node_index
+                                                                        + 1
+                                                                        - NODE_NUMBERING_OFFSET][0])
+                                                                        as usize,
+                                                                    (2.0 * nodal_coordinates[*node_index
+                                                                        + 1
+                                                                        - NODE_NUMBERING_OFFSET][1])
+                                                                        as usize,
+                                                                    (2.0 * nodal_coordinates[*node_index
+                                                                        + 1
+                                                                        - NODE_NUMBERING_OFFSET][2])
+                                                                        as usize,
+                                                                ),
+                                                                *node_index + 1,
+                                                            );
+                                                            element_node_connectivity.push([
+                                                                cells_nodes[cell_subcells[3]],
+                                                                cells_nodes[subcell_3_face_1_subcells[2]],
+                                                                cells_nodes[diagonal_1],
+                                                                cells_nodes[subcell_3_face_2_subcells[1]],
+                                                                *node_index,
+                                                                cells_nodes
+                                                                    [subcell_3_face_1_subcells[6]],
+                                                                cells_nodes[subdiagonal_1],
+                                                                cells_nodes
+                                                                    [subcell_3_face_2_subcells[5]],
+                                                            ]);
+                                                            element_node_connectivity.push([
+                                                                *node_index,
+                                                                cells_nodes
+                                                                    [subcell_3_face_1_subcells[6]],
+                                                                cells_nodes[subdiagonal_1],
+                                                                cells_nodes
+                                                                    [subcell_3_face_2_subcells[5]],
+                                                                *node_index + 1,
+                                                                cells_nodes
+                                                                    [subcell_7_face_1_subcells[2]],
+                                                                cells_nodes[subdiagonal_2],
+                                                                cells_nodes
+                                                                    [subcell_7_face_2_subcells[1]],
+                                                            ]);
+                                                            element_node_connectivity.push([
+                                                                *node_index + 1,
+                                                                cells_nodes
+                                                                    [subcell_7_face_1_subcells[2]],
+                                                                cells_nodes[subdiagonal_2],
+                                                                cells_nodes
+                                                                    [subcell_7_face_2_subcells[1]],
+                                                                cells_nodes[cell_subcells[7]],
+                                                                cells_nodes[subcell_7_face_1_subcells[6]],
+                                                                cells_nodes[diagonal_2],
+                                                                cells_nodes[subcell_7_face_2_subcells[5]],
+                                                            ]);
+                                                            *node_index += 2;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+}
+
+fn template(
+    cells_nodes: &Vec<usize>,
+    cell_subcells: &[usize; NUM_OCTANTS],
+    nodes_map: &mut NodeMap,
+    node_index: &mut usize,
+    subcell_a: usize,
+    subcell_b: usize,
+    tree: &Octree,
+    element_node_connectivity: &mut HexConnectivity,
+    nodal_coordinates: &mut Coordinates,
+) {
+    //
+    // need to match subcells (2 and 6 everywhere, plus stuff in connectivity)
+    //
+    // need to match sign and direction of `bar`
+    //
+    let (face_a_index, face_b_index) = match (subcell_a, subcell_b) {
+        (3, 7) => (1, 2),
+        _=> panic!(),
+    };
+    let subcell_a_faces = tree[cell_subcells[subcell_a]].get_faces();
+    if let Some(subcell_a_face_a) = subcell_a_faces[face_a_index] {
+        if let Some(subcell_a_face_b) = subcell_a_faces[face_b_index] {
+            if let Some((subcell_a_face_a_subcells, _)) =
+                tree.cell_contains_leaves(&tree[subcell_a_face_a])
+            {
+                if let Some((subcell_a_face_b_subcells, _)) =
+                    tree.cell_contains_leaves(&tree[subcell_a_face_b])
+                {
+                    if let Some(diagonal_a) = tree[subcell_a_face_a_subcells[2]].get_faces()[face_b_index] {
+                        if let Some(subdiagonal_a) =
+                            tree[subcell_a_face_a_subcells[6]].get_faces()[face_b_index]
+                        {
+                            let subcell_b_faces = tree[cell_subcells[subcell_a]].get_faces();
+                            if let Some(subcell_b_face_a) = subcell_b_faces[face_a_index] {
+                                if let Some(subcell_b_face_b) = subcell_b_faces[2] {
+                                    if let Some((subcell_b_face_a_subcells, _)) =
+                                        tree.cell_contains_leaves(&tree[subcell_b_face_a])
+                                    {
+                                        if let Some((subcell_b_face_b_subcells, _)) =
+                                            tree.cell_contains_leaves(&tree[subcell_b_face_b])
+                                        {
+                                            if let Some(diagonal_b) =
+                                                tree[subcell_b_face_a_subcells[6]].get_faces()[face_b_index]
+                                            {
+                                                if let Some(subdiagonal_b) = tree
+                                                    [subcell_b_face_a_subcells[2]]
+                                                    .get_faces()[face_b_index]
+                                                {
+                                                    let lngth = *tree[subcell_a_face_a_subcells[6]]
+                                                        .get_lngth()
+                                                        as f64;
+                                                    let bar =
+                                                        tensor_rank_1([-2.0 * lngth, 0.0, 0.0]);
+                                                    nodal_coordinates.push(
+                                                        &nodal_coordinates[cells_nodes
+                                                            [subcell_a_face_a_subcells[6]]]
+                                                            + bar.clone(),
+                                                    );
+                                                    nodal_coordinates.push(
+                                                        &nodal_coordinates[cells_nodes
+                                                            [subcell_b_face_a_subcells[2]]]
+                                                            + bar.clone(),
+                                                    );
+                                                    nodes_map.insert(
+                                                        (
+                                                            (2.0 * nodal_coordinates[*node_index
+                                                                - NODE_NUMBERING_OFFSET][0])
+                                                                as usize,
+                                                            (2.0 * nodal_coordinates[*node_index
+                                                                - NODE_NUMBERING_OFFSET][1])
+                                                                as usize,
+                                                            (2.0 * nodal_coordinates[*node_index
+                                                                - NODE_NUMBERING_OFFSET][2])
+                                                                as usize,
+                                                        ),
+                                                        *node_index,
+                                                    );
+                                                    nodes_map.insert(
+                                                        (
+                                                            (2.0 * nodal_coordinates[*node_index
+                                                                + 1
+                                                                - NODE_NUMBERING_OFFSET][0])
+                                                                as usize,
+                                                            (2.0 * nodal_coordinates[*node_index
+                                                                + 1
+                                                                - NODE_NUMBERING_OFFSET][1])
+                                                                as usize,
+                                                            (2.0 * nodal_coordinates[*node_index
+                                                                + 1
+                                                                - NODE_NUMBERING_OFFSET][2])
+                                                                as usize,
+                                                        ),
+                                                        *node_index + 1,
+                                                    );
+                                                    element_node_connectivity.push([
+                                                        cells_nodes[cell_subcells[3]],
+                                                        cells_nodes[subcell_a_face_a_subcells[2]],
+                                                        cells_nodes[diagonal_a],
+                                                        cells_nodes[subcell_a_face_b_subcells[1]],
+                                                        *node_index,
+                                                        cells_nodes[subcell_a_face_a_subcells[6]],
+                                                        cells_nodes[subdiagonal_a],
+                                                        cells_nodes[subcell_a_face_b_subcells[5]],
+                                                    ]);
+                                                    element_node_connectivity.push([
+                                                        *node_index,
+                                                        cells_nodes[subcell_a_face_a_subcells[6]],
+                                                        cells_nodes[subdiagonal_a],
+                                                        cells_nodes[subcell_a_face_b_subcells[5]],
+                                                        *node_index + 1,
+                                                        cells_nodes[subcell_b_face_a_subcells[2]],
+                                                        cells_nodes[subdiagonal_b],
+                                                        cells_nodes[subcell_b_face_b_subcells[1]],
+                                                    ]);
+                                                    element_node_connectivity.push([
+                                                        *node_index + 1,
+                                                        cells_nodes[subcell_b_face_a_subcells[2]],
+                                                        cells_nodes[subdiagonal_b],
+                                                        cells_nodes[subcell_b_face_b_subcells[1]],
+                                                        cells_nodes[cell_subcells[7]],
+                                                        cells_nodes[subcell_b_face_a_subcells[6]],
+                                                        cells_nodes[diagonal_b],
+                                                        cells_nodes[subcell_b_face_b_subcells[5]],
+                                                    ]);
+                                                    *node_index += 2;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/tree/hex/edge_template_1/mod.rs
+++ b/src/tree/hex/edge_template_1/mod.rs
@@ -12,6 +12,7 @@ pub fn apply(
     tree.iter()
         .filter_map(|cell| tree.cell_contains_leaves(cell))
         .for_each(|(cell_subcells, _)| {
+            template(2, 6, cells_nodes, &cell_subcells, nodes_map, node_index, tree, element_node_connectivity, nodal_coordinates);
             template(3, 7, cells_nodes, &cell_subcells, nodes_map, node_index, tree, element_node_connectivity, nodal_coordinates)
         })
 }
@@ -28,9 +29,13 @@ fn template(
     nodal_coordinates: &mut Coordinates,
 ) {
     let (face_m, face_n, subcell_c, subcell_d, subcell_e, subcell_f, direction) = match (subcell_a, subcell_b) {
+        (2, 6) => (2, 3, 0, 3, 4, 7, tensor_rank_1::<3, 1>([0.0, -2.0, 0.0])),
         (3, 7) => (1, 2, 2, 1, 6, 5, tensor_rank_1::<3, 1>([-2.0, 0.0, 0.0])),
         _=> panic!(),
     };
+    //
+    // change names below to match new scheme (a, b) -> (m, n, c, d, e, f)
+    //
     let subcell_a_faces = tree[cell_subcells[subcell_a]].get_faces();
     if let Some(subcell_a_face_a) = subcell_a_faces[face_m] {
         if let Some(subcell_a_face_b) = subcell_a_faces[face_n] {
@@ -44,7 +49,7 @@ fn template(
                         if let Some(subdiagonal_a) =
                             tree[subcell_a_face_a_subcells[subcell_e]].get_faces()[face_n]
                         {
-                            let subcell_b_faces = tree[cell_subcells[subcell_a]].get_faces();
+                            let subcell_b_faces = tree[cell_subcells[subcell_b]].get_faces();
                             if let Some(subcell_b_face_a) = subcell_b_faces[face_m] {
                                 if let Some(subcell_b_face_b) = subcell_b_faces[face_n] {
                                     if let Some((subcell_b_face_a_subcells, _)) =

--- a/src/tree/hex/edge_template_1/mod.rs
+++ b/src/tree/hex/edge_template_1/mod.rs
@@ -12,178 +12,41 @@ pub fn apply(
     tree.iter()
         .filter_map(|cell| tree.cell_contains_leaves(cell))
         .for_each(|(cell_subcells, _)| {
-            let subcell_3_faces = tree[cell_subcells[3]].get_faces();
-            if let Some(subcell_3_face_1) = subcell_3_faces[1] {
-                if let Some(subcell_3_face_2) = subcell_3_faces[2] {
-                    if let Some((subcell_3_face_1_subcells, _)) =
-                        tree.cell_contains_leaves(&tree[subcell_3_face_1])
-                    {
-                        if let Some((subcell_3_face_2_subcells, _)) =
-                            tree.cell_contains_leaves(&tree[subcell_3_face_2])
-                        {
-                            if let Some(diagonal_1) =
-                                tree[subcell_3_face_1_subcells[2]].get_faces()[2]
-                            {
-                                if let Some(subdiagonal_1) =
-                                    tree[subcell_3_face_1_subcells[6]].get_faces()[2]
-                                {
-                                    let subcell_7_faces = tree[cell_subcells[7]].get_faces();
-                                    if let Some(subcell_7_face_1) = subcell_7_faces[1] {
-                                        if let Some(subcell_7_face_2) = subcell_7_faces[2] {
-                                            if let Some((subcell_7_face_1_subcells, _)) =
-                                                tree.cell_contains_leaves(&tree[subcell_7_face_1])
-                                            {
-                                                if let Some((subcell_7_face_2_subcells, _)) = tree
-                                                    .cell_contains_leaves(&tree[subcell_7_face_2])
-                                                {
-                                                    if let Some(diagonal_2) = tree
-                                                        [subcell_7_face_1_subcells[6]]
-                                                        .get_faces()[2]
-                                                    {
-                                                        if let Some(subdiagonal_2) = tree
-                                                            [subcell_7_face_1_subcells[2]]
-                                                            .get_faces()[2]
-                                                        {
-                                                            let lngth = *tree
-                                                                [subcell_3_face_1_subcells[6]]
-                                                                .get_lngth()
-                                                                as f64;
-                                                            let bar = tensor_rank_1([
-                                                                -2.0 * lngth,
-                                                                0.0,
-                                                                0.0,
-                                                            ]);
-                                                            nodal_coordinates.push(
-                                                                &nodal_coordinates[cells_nodes
-                                                                    [subcell_3_face_1_subcells[6]]]
-                                                                    + bar.clone(),
-                                                            );
-                                                            nodal_coordinates.push(
-                                                                &nodal_coordinates[cells_nodes
-                                                                    [subcell_7_face_1_subcells[2]]]
-                                                                    + bar.clone(),
-                                                            );
-                                                            nodes_map.insert(
-                                                                (
-                                                                    (2.0 * nodal_coordinates[*node_index
-                                                                        - NODE_NUMBERING_OFFSET][0])
-                                                                        as usize,
-                                                                    (2.0 * nodal_coordinates[*node_index
-                                                                        - NODE_NUMBERING_OFFSET][1])
-                                                                        as usize,
-                                                                    (2.0 * nodal_coordinates[*node_index
-                                                                        - NODE_NUMBERING_OFFSET][2])
-                                                                        as usize,
-                                                                ),
-                                                                *node_index,
-                                                            );
-                                                            nodes_map.insert(
-                                                                (
-                                                                    (2.0 * nodal_coordinates[*node_index
-                                                                        + 1
-                                                                        - NODE_NUMBERING_OFFSET][0])
-                                                                        as usize,
-                                                                    (2.0 * nodal_coordinates[*node_index
-                                                                        + 1
-                                                                        - NODE_NUMBERING_OFFSET][1])
-                                                                        as usize,
-                                                                    (2.0 * nodal_coordinates[*node_index
-                                                                        + 1
-                                                                        - NODE_NUMBERING_OFFSET][2])
-                                                                        as usize,
-                                                                ),
-                                                                *node_index + 1,
-                                                            );
-                                                            element_node_connectivity.push([
-                                                                cells_nodes[cell_subcells[3]],
-                                                                cells_nodes[subcell_3_face_1_subcells[2]],
-                                                                cells_nodes[diagonal_1],
-                                                                cells_nodes[subcell_3_face_2_subcells[1]],
-                                                                *node_index,
-                                                                cells_nodes
-                                                                    [subcell_3_face_1_subcells[6]],
-                                                                cells_nodes[subdiagonal_1],
-                                                                cells_nodes
-                                                                    [subcell_3_face_2_subcells[5]],
-                                                            ]);
-                                                            element_node_connectivity.push([
-                                                                *node_index,
-                                                                cells_nodes
-                                                                    [subcell_3_face_1_subcells[6]],
-                                                                cells_nodes[subdiagonal_1],
-                                                                cells_nodes
-                                                                    [subcell_3_face_2_subcells[5]],
-                                                                *node_index + 1,
-                                                                cells_nodes
-                                                                    [subcell_7_face_1_subcells[2]],
-                                                                cells_nodes[subdiagonal_2],
-                                                                cells_nodes
-                                                                    [subcell_7_face_2_subcells[1]],
-                                                            ]);
-                                                            element_node_connectivity.push([
-                                                                *node_index + 1,
-                                                                cells_nodes
-                                                                    [subcell_7_face_1_subcells[2]],
-                                                                cells_nodes[subdiagonal_2],
-                                                                cells_nodes
-                                                                    [subcell_7_face_2_subcells[1]],
-                                                                cells_nodes[cell_subcells[7]],
-                                                                cells_nodes[subcell_7_face_1_subcells[6]],
-                                                                cells_nodes[diagonal_2],
-                                                                cells_nodes[subcell_7_face_2_subcells[5]],
-                                                            ]);
-                                                            *node_index += 2;
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            template(3, 7, cells_nodes, &cell_subcells, nodes_map, node_index, tree, element_node_connectivity, nodal_coordinates)
         })
 }
 
 fn template(
+    subcell_a: usize,
+    subcell_b: usize,
     cells_nodes: &Vec<usize>,
     cell_subcells: &[usize; NUM_OCTANTS],
     nodes_map: &mut NodeMap,
     node_index: &mut usize,
-    subcell_a: usize,
-    subcell_b: usize,
     tree: &Octree,
     element_node_connectivity: &mut HexConnectivity,
     nodal_coordinates: &mut Coordinates,
 ) {
-    //
-    // need to match subcells (2 and 6 everywhere, plus stuff in connectivity)
-    //
-    // need to match sign and direction of `bar`
-    //
-    let (face_a_index, face_b_index) = match (subcell_a, subcell_b) {
-        (3, 7) => (1, 2),
+    let (face_m, face_n, subcell_c, subcell_d, subcell_e, subcell_f, direction) = match (subcell_a, subcell_b) {
+        (3, 7) => (1, 2, 2, 1, 6, 5, tensor_rank_1::<3, 1>([-2.0, 0.0, 0.0])),
         _=> panic!(),
     };
     let subcell_a_faces = tree[cell_subcells[subcell_a]].get_faces();
-    if let Some(subcell_a_face_a) = subcell_a_faces[face_a_index] {
-        if let Some(subcell_a_face_b) = subcell_a_faces[face_b_index] {
+    if let Some(subcell_a_face_a) = subcell_a_faces[face_m] {
+        if let Some(subcell_a_face_b) = subcell_a_faces[face_n] {
             if let Some((subcell_a_face_a_subcells, _)) =
                 tree.cell_contains_leaves(&tree[subcell_a_face_a])
             {
                 if let Some((subcell_a_face_b_subcells, _)) =
                     tree.cell_contains_leaves(&tree[subcell_a_face_b])
                 {
-                    if let Some(diagonal_a) = tree[subcell_a_face_a_subcells[2]].get_faces()[face_b_index] {
+                    if let Some(diagonal_a) = tree[subcell_a_face_a_subcells[subcell_c]].get_faces()[face_n] {
                         if let Some(subdiagonal_a) =
-                            tree[subcell_a_face_a_subcells[6]].get_faces()[face_b_index]
+                            tree[subcell_a_face_a_subcells[subcell_e]].get_faces()[face_n]
                         {
                             let subcell_b_faces = tree[cell_subcells[subcell_a]].get_faces();
-                            if let Some(subcell_b_face_a) = subcell_b_faces[face_a_index] {
-                                if let Some(subcell_b_face_b) = subcell_b_faces[2] {
+                            if let Some(subcell_b_face_a) = subcell_b_faces[face_m] {
+                                if let Some(subcell_b_face_b) = subcell_b_faces[face_n] {
                                     if let Some((subcell_b_face_a_subcells, _)) =
                                         tree.cell_contains_leaves(&tree[subcell_b_face_a])
                                     {
@@ -191,26 +54,24 @@ fn template(
                                             tree.cell_contains_leaves(&tree[subcell_b_face_b])
                                         {
                                             if let Some(diagonal_b) =
-                                                tree[subcell_b_face_a_subcells[6]].get_faces()[face_b_index]
+                                                tree[subcell_b_face_a_subcells[subcell_e]].get_faces()[face_n]
                                             {
                                                 if let Some(subdiagonal_b) = tree
-                                                    [subcell_b_face_a_subcells[2]]
-                                                    .get_faces()[face_b_index]
+                                                    [subcell_b_face_a_subcells[subcell_c]]
+                                                    .get_faces()[face_n]
                                                 {
-                                                    let lngth = *tree[subcell_a_face_a_subcells[6]]
+                                                    let lngth = *tree[subcell_a_face_a_subcells[subcell_e]]
                                                         .get_lngth()
                                                         as f64;
-                                                    let bar =
-                                                        tensor_rank_1([-2.0 * lngth, 0.0, 0.0]);
                                                     nodal_coordinates.push(
                                                         &nodal_coordinates[cells_nodes
-                                                            [subcell_a_face_a_subcells[6]]]
-                                                            + bar.clone(),
+                                                            [subcell_a_face_a_subcells[subcell_e]]]
+                                                            + &direction * lngth,
                                                     );
                                                     nodal_coordinates.push(
                                                         &nodal_coordinates[cells_nodes
-                                                            [subcell_b_face_a_subcells[2]]]
-                                                            + bar.clone(),
+                                                            [subcell_b_face_a_subcells[subcell_c]]]
+                                                            + direction * lngth,
                                                     );
                                                     nodes_map.insert(
                                                         (
@@ -244,34 +105,34 @@ fn template(
                                                         *node_index + 1,
                                                     );
                                                     element_node_connectivity.push([
-                                                        cells_nodes[cell_subcells[3]],
-                                                        cells_nodes[subcell_a_face_a_subcells[2]],
+                                                        cells_nodes[cell_subcells[subcell_a]],
+                                                        cells_nodes[subcell_a_face_a_subcells[subcell_c]],
                                                         cells_nodes[diagonal_a],
-                                                        cells_nodes[subcell_a_face_b_subcells[1]],
+                                                        cells_nodes[subcell_a_face_b_subcells[subcell_d]],
                                                         *node_index,
-                                                        cells_nodes[subcell_a_face_a_subcells[6]],
+                                                        cells_nodes[subcell_a_face_a_subcells[subcell_e]],
                                                         cells_nodes[subdiagonal_a],
-                                                        cells_nodes[subcell_a_face_b_subcells[5]],
+                                                        cells_nodes[subcell_a_face_b_subcells[subcell_f]],
                                                     ]);
                                                     element_node_connectivity.push([
                                                         *node_index,
-                                                        cells_nodes[subcell_a_face_a_subcells[6]],
+                                                        cells_nodes[subcell_a_face_a_subcells[subcell_e]],
                                                         cells_nodes[subdiagonal_a],
-                                                        cells_nodes[subcell_a_face_b_subcells[5]],
+                                                        cells_nodes[subcell_a_face_b_subcells[subcell_f]],
                                                         *node_index + 1,
-                                                        cells_nodes[subcell_b_face_a_subcells[2]],
+                                                        cells_nodes[subcell_b_face_a_subcells[subcell_c]],
                                                         cells_nodes[subdiagonal_b],
-                                                        cells_nodes[subcell_b_face_b_subcells[1]],
+                                                        cells_nodes[subcell_b_face_b_subcells[subcell_d]],
                                                     ]);
                                                     element_node_connectivity.push([
                                                         *node_index + 1,
-                                                        cells_nodes[subcell_b_face_a_subcells[2]],
+                                                        cells_nodes[subcell_b_face_a_subcells[subcell_c]],
                                                         cells_nodes[subdiagonal_b],
-                                                        cells_nodes[subcell_b_face_b_subcells[1]],
-                                                        cells_nodes[cell_subcells[7]],
-                                                        cells_nodes[subcell_b_face_a_subcells[6]],
+                                                        cells_nodes[subcell_b_face_b_subcells[subcell_d]],
+                                                        cells_nodes[cell_subcells[subcell_b]],
+                                                        cells_nodes[subcell_b_face_a_subcells[subcell_e]],
                                                         cells_nodes[diagonal_b],
-                                                        cells_nodes[subcell_b_face_b_subcells[5]],
+                                                        cells_nodes[subcell_b_face_b_subcells[subcell_f]],
                                                     ]);
                                                     *node_index += 2;
                                                 }

--- a/src/tree/hex/edge_template_1/mod.rs
+++ b/src/tree/hex/edge_template_1/mod.rs
@@ -1,8 +1,10 @@
-use super::super::{Coordinates, HexConnectivity, NODE_NUMBERING_OFFSET, NUM_OCTANTS, NodeMap, Octree};
+use super::super::{
+    Coordinates, HexConnectivity, NODE_NUMBERING_OFFSET, NUM_OCTANTS, NodeMap, Octree,
+};
 use conspire::math::{TensorVec, tensor_rank_1};
 
 pub fn apply(
-    cells_nodes: &Vec<usize>,
+    cells_nodes: &[usize],
     nodes_map: &mut NodeMap,
     node_index: &mut usize,
     tree: &Octree,
@@ -12,15 +14,146 @@ pub fn apply(
     tree.iter()
         .filter_map(|cell| tree.cell_contains_leaves(cell))
         .for_each(|(cell_subcells, _)| {
-            template(2, 6, cells_nodes, &cell_subcells, nodes_map, node_index, tree, element_node_connectivity, nodal_coordinates);
-            template(3, 7, cells_nodes, &cell_subcells, nodes_map, node_index, tree, element_node_connectivity, nodal_coordinates)
+            template(
+                0,
+                1,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                0,
+                2,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                0,
+                4,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                1,
+                3,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                1,
+                5,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                2,
+                3,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                2,
+                6,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                3,
+                7,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                4,
+                5,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                4,
+                6,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                5,
+                7,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                6,
+                7,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                node_index,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
         })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn template(
     subcell_a: usize,
     subcell_b: usize,
-    cells_nodes: &Vec<usize>,
+    cells_nodes: &[usize],
     cell_subcells: &[usize; NUM_OCTANTS],
     nodes_map: &mut NodeMap,
     node_index: &mut usize,
@@ -28,57 +161,107 @@ fn template(
     element_node_connectivity: &mut HexConnectivity,
     nodal_coordinates: &mut Coordinates,
 ) {
-    let (face_m, face_n, subcell_c, subcell_d, subcell_e, subcell_f, direction) = match (subcell_a, subcell_b) {
-        (2, 6) => (2, 3, 0, 3, 4, 7, tensor_rank_1::<3, 1>([0.0, -2.0, 0.0])),
-        (3, 7) => (1, 2, 2, 1, 6, 5, tensor_rank_1::<3, 1>([-2.0, 0.0, 0.0])),
-        _=> panic!(),
-    };
-    //
-    // change names below to match new scheme (a, b) -> (m, n, c, d, e, f)
-    //
+    let (face_m, face_n, subcell_c, subcell_d, subcell_e, subcell_f, direction) =
+        match (subcell_a, subcell_b) {
+            (0, 1) => (0, 4, 2, 4, 3, 5, tensor_rank_1::<3, 1>([0.0, 1.0, 0.0])),
+            (0, 2) => (3, 4, 1, 4, 3, 6, tensor_rank_1::<3, 1>([1.0, 0.0, 0.0])),
+            (0, 4) => (3, 0, 1, 2, 5, 6, tensor_rank_1::<3, 1>([1.0, 0.0, 0.0])),
+            (1, 3) => (1, 4, 0, 5, 2, 7, tensor_rank_1::<3, 1>([-1.0, 0.0, 0.0])),
+            (1, 5) => (0, 1, 3, 0, 7, 4, tensor_rank_1::<3, 1>([0.0, 1.0, 0.0])),
+            (2, 3) => (2, 4, 0, 6, 1, 7, tensor_rank_1::<3, 1>([0.0, -1.0, 0.0])),
+            (2, 6) => (2, 3, 0, 3, 4, 7, tensor_rank_1::<3, 1>([0.0, -1.0, 0.0])),
+            (3, 7) => (1, 2, 2, 1, 6, 5, tensor_rank_1::<3, 1>([-1.0, 0.0, 0.0])),
+            (4, 5) => (5, 0, 0, 6, 1, 7, tensor_rank_1::<3, 1>([0.0, 0.0, -1.0])),
+            (4, 6) => (5, 3, 0, 5, 2, 7, tensor_rank_1::<3, 1>([0.0, 0.0, -1.0])),
+            (5, 7) => (5, 1, 1, 4, 3, 6, tensor_rank_1::<3, 1>([0.0, 0.0, -1.0])),
+            (6, 7) => (5, 2, 2, 4, 3, 5, tensor_rank_1::<3, 1>([0.0, 0.0, -1.0])),
+            _ => panic!(),
+        };
     let subcell_a_faces = tree[cell_subcells[subcell_a]].get_faces();
-    if let Some(subcell_a_face_a) = subcell_a_faces[face_m] {
-        if let Some(subcell_a_face_b) = subcell_a_faces[face_n] {
-            if let Some((subcell_a_face_a_subcells, _)) =
-                tree.cell_contains_leaves(&tree[subcell_a_face_a])
+    if let Some(subcell_a_face_m) = subcell_a_faces[face_m] {
+        if let Some(subcell_a_face_n) = subcell_a_faces[face_n] {
+            if let Some((subcell_a_face_m_subcells, _)) =
+                tree.cell_contains_leaves(&tree[subcell_a_face_m])
             {
-                if let Some((subcell_a_face_b_subcells, _)) =
-                    tree.cell_contains_leaves(&tree[subcell_a_face_b])
+                if let Some((subcell_a_face_n_subcells, _)) =
+                    tree.cell_contains_leaves(&tree[subcell_a_face_n])
                 {
-                    if let Some(diagonal_a) = tree[subcell_a_face_a_subcells[subcell_c]].get_faces()[face_n] {
+                    if let Some(diagonal_a) =
+                        tree[subcell_a_face_m_subcells[subcell_c]].get_faces()[face_n]
+                    {
                         if let Some(subdiagonal_a) =
-                            tree[subcell_a_face_a_subcells[subcell_e]].get_faces()[face_n]
+                            tree[subcell_a_face_m_subcells[subcell_e]].get_faces()[face_n]
                         {
                             let subcell_b_faces = tree[cell_subcells[subcell_b]].get_faces();
-                            if let Some(subcell_b_face_a) = subcell_b_faces[face_m] {
-                                if let Some(subcell_b_face_b) = subcell_b_faces[face_n] {
-                                    if let Some((subcell_b_face_a_subcells, _)) =
-                                        tree.cell_contains_leaves(&tree[subcell_b_face_a])
+                            if let Some(subcell_b_face_m) = subcell_b_faces[face_m] {
+                                if let Some(subcell_b_face_n) = subcell_b_faces[face_n] {
+                                    if let Some((subcell_b_face_m_subcells, _)) =
+                                        tree.cell_contains_leaves(&tree[subcell_b_face_m])
                                     {
-                                        if let Some((subcell_b_face_b_subcells, _)) =
-                                            tree.cell_contains_leaves(&tree[subcell_b_face_b])
+                                        if let Some((subcell_b_face_n_subcells, _)) =
+                                            tree.cell_contains_leaves(&tree[subcell_b_face_n])
                                         {
-                                            if let Some(diagonal_b) =
-                                                tree[subcell_b_face_a_subcells[subcell_e]].get_faces()[face_n]
+                                            if let Some(diagonal_b) = tree
+                                                [subcell_b_face_m_subcells[subcell_e]]
+                                                .get_faces()[face_n]
                                             {
                                                 if let Some(subdiagonal_b) = tree
-                                                    [subcell_b_face_a_subcells[subcell_c]]
+                                                    [subcell_b_face_m_subcells[subcell_c]]
                                                     .get_faces()[face_n]
                                                 {
-                                                    let lngth = *tree[subcell_a_face_a_subcells[subcell_e]]
+                                                    if cells_nodes[diagonal_a] == 0 {
+                                                        println!(
+                                                            "Cell diagonal_a={} is node 0, leaf is {}",
+                                                            diagonal_a,
+                                                            tree[diagonal_a].is_leaf()
+                                                        );
+                                                    } else {
+                                                        assert!(tree[diagonal_a].is_leaf())
+                                                    }
+                                                    if cells_nodes[diagonal_b] == 0 {
+                                                        println!(
+                                                            "Cell diagonal_b={} is node 0, leaf is {}",
+                                                            diagonal_b,
+                                                            tree[diagonal_b].is_leaf()
+                                                        );
+                                                    } else {
+                                                        assert!(tree[diagonal_b].is_leaf())
+                                                    }
+                                                    if cells_nodes[subdiagonal_a] == 0 {
+                                                        println!(
+                                                            "Cell subdiagonal_a={} is node 0, leaf is {}",
+                                                            subdiagonal_a,
+                                                            tree[subdiagonal_a].is_leaf()
+                                                        );
+                                                    } else {
+                                                        assert!(tree[subdiagonal_a].is_leaf())
+                                                    }
+                                                    if cells_nodes[subdiagonal_b] == 0 {
+                                                        println!(
+                                                            "Cell subdiagonal_b={} is node 0, leaf is {}",
+                                                            subdiagonal_b,
+                                                            tree[subdiagonal_b].is_leaf()
+                                                        );
+                                                    } else {
+                                                        assert!(tree[subdiagonal_b].is_leaf())
+                                                    }
+                                                    let lngth = *tree
+                                                        [subcell_a_face_m_subcells[subcell_e]]
                                                         .get_lngth()
                                                         as f64;
                                                     nodal_coordinates.push(
                                                         &nodal_coordinates[cells_nodes
-                                                            [subcell_a_face_a_subcells[subcell_e]]]
+                                                            [subcell_a_face_m_subcells[subcell_e]]
+                                                            - NODE_NUMBERING_OFFSET]
                                                             + &direction * lngth,
                                                     );
                                                     nodal_coordinates.push(
                                                         &nodal_coordinates[cells_nodes
-                                                            [subcell_b_face_a_subcells[subcell_c]]]
+                                                            [subcell_b_face_m_subcells[subcell_c]]
+                                                            - NODE_NUMBERING_OFFSET]
                                                             + direction * lngth,
                                                     );
-                                                    nodes_map.insert(
+                                                    assert!(nodes_map.insert(
                                                         (
                                                             (2.0 * nodal_coordinates[*node_index
                                                                 - NODE_NUMBERING_OFFSET][0])
@@ -91,8 +274,8 @@ fn template(
                                                                 as usize,
                                                         ),
                                                         *node_index,
-                                                    );
-                                                    nodes_map.insert(
+                                                    ).is_none(), "duplicate entry");
+                                                    assert!(nodes_map.insert(
                                                         (
                                                             (2.0 * nodal_coordinates[*node_index
                                                                 + 1
@@ -108,36 +291,48 @@ fn template(
                                                                 as usize,
                                                         ),
                                                         *node_index + 1,
-                                                    );
+                                                    ).is_none(), "duplicate entry");
                                                     element_node_connectivity.push([
                                                         cells_nodes[cell_subcells[subcell_a]],
-                                                        cells_nodes[subcell_a_face_a_subcells[subcell_c]],
+                                                        cells_nodes
+                                                            [subcell_a_face_m_subcells[subcell_c]],
                                                         cells_nodes[diagonal_a],
-                                                        cells_nodes[subcell_a_face_b_subcells[subcell_d]],
+                                                        cells_nodes
+                                                            [subcell_a_face_n_subcells[subcell_d]],
                                                         *node_index,
-                                                        cells_nodes[subcell_a_face_a_subcells[subcell_e]],
+                                                        cells_nodes
+                                                            [subcell_a_face_m_subcells[subcell_e]],
                                                         cells_nodes[subdiagonal_a],
-                                                        cells_nodes[subcell_a_face_b_subcells[subcell_f]],
+                                                        cells_nodes
+                                                            [subcell_a_face_n_subcells[subcell_f]],
                                                     ]);
                                                     element_node_connectivity.push([
                                                         *node_index,
-                                                        cells_nodes[subcell_a_face_a_subcells[subcell_e]],
+                                                        cells_nodes
+                                                            [subcell_a_face_m_subcells[subcell_e]],
                                                         cells_nodes[subdiagonal_a],
-                                                        cells_nodes[subcell_a_face_b_subcells[subcell_f]],
+                                                        cells_nodes
+                                                            [subcell_a_face_n_subcells[subcell_f]],
                                                         *node_index + 1,
-                                                        cells_nodes[subcell_b_face_a_subcells[subcell_c]],
+                                                        cells_nodes
+                                                            [subcell_b_face_m_subcells[subcell_c]],
                                                         cells_nodes[subdiagonal_b],
-                                                        cells_nodes[subcell_b_face_b_subcells[subcell_d]],
+                                                        cells_nodes
+                                                            [subcell_b_face_n_subcells[subcell_d]],
                                                     ]);
                                                     element_node_connectivity.push([
                                                         *node_index + 1,
-                                                        cells_nodes[subcell_b_face_a_subcells[subcell_c]],
+                                                        cells_nodes
+                                                            [subcell_b_face_m_subcells[subcell_c]],
                                                         cells_nodes[subdiagonal_b],
-                                                        cells_nodes[subcell_b_face_b_subcells[subcell_d]],
+                                                        cells_nodes
+                                                            [subcell_b_face_n_subcells[subcell_d]],
                                                         cells_nodes[cell_subcells[subcell_b]],
-                                                        cells_nodes[subcell_b_face_a_subcells[subcell_e]],
+                                                        cells_nodes
+                                                            [subcell_b_face_m_subcells[subcell_e]],
                                                         cells_nodes[diagonal_b],
-                                                        cells_nodes[subcell_b_face_b_subcells[subcell_f]],
+                                                        cells_nodes
+                                                            [subcell_b_face_n_subcells[subcell_f]],
                                                     ]);
                                                     *node_index += 2;
                                                 }

--- a/src/tree/hex/face_template_0/mod.rs
+++ b/src/tree/hex/face_template_0/mod.rs
@@ -1,0 +1,171 @@
+use super::super::{HexConnectivity, NUM_FACES, NUM_OCTANTS, Octree};
+
+pub fn apply(
+    cells_nodes: &Vec<usize>,
+    tree: &Octree,
+    element_node_connectivity: &mut HexConnectivity,
+) {
+    let mut connected_faces = [None; NUM_FACES];
+    let mut d_01_subcells = None;
+    let mut d_04_subcells = None;
+    let mut d_14_subcells = None;
+    let mut d014_subcells = None;
+    let mut fa_0_subcells = [0; NUM_OCTANTS];
+    let mut fa_1_subcells = [0; NUM_OCTANTS];
+    let mut fa_4_subcells = [0; NUM_OCTANTS];
+    let mut face_0_faces = &[None; NUM_FACES];
+    tree.iter()
+        .filter_map(|cell| tree.cell_contains_leaves(cell))
+        .for_each(|(cell_subcells, cell_faces)| {
+            connected_faces = [None; NUM_FACES];
+            d_01_subcells = None;
+            d_04_subcells = None;
+            d_14_subcells = None;
+            d014_subcells = None;
+            cell_faces
+                .iter()
+                .enumerate()
+                .for_each(|(face_index, face_cell)| {
+                    if let Some(face_cell_index) = face_cell {
+                        if let Some(face_subcells) = tree[*face_cell_index].get_cells() {
+                            if tree.just_leaves(face_subcells) {
+                                match face_index {
+                                    0 => {
+                                        element_node_connectivity.push([
+                                            cells_nodes[face_subcells[2]],
+                                            cells_nodes[face_subcells[3]],
+                                            cells_nodes[cell_subcells[1]],
+                                            cells_nodes[cell_subcells[0]],
+                                            cells_nodes[face_subcells[6]],
+                                            cells_nodes[face_subcells[7]],
+                                            cells_nodes[cell_subcells[5]],
+                                            cells_nodes[cell_subcells[4]],
+                                        ]);
+                                        connected_faces[0] = Some(face_cell_index)
+                                    }
+                                    1 => {
+                                        element_node_connectivity.push([
+                                            cells_nodes[cell_subcells[1]],
+                                            cells_nodes[face_subcells[0]],
+                                            cells_nodes[face_subcells[2]],
+                                            cells_nodes[cell_subcells[3]],
+                                            cells_nodes[cell_subcells[5]],
+                                            cells_nodes[face_subcells[4]],
+                                            cells_nodes[face_subcells[6]],
+                                            cells_nodes[cell_subcells[7]],
+                                        ]);
+                                        connected_faces[1] = Some(face_cell_index)
+                                    }
+                                    4 => {
+                                        element_node_connectivity.push([
+                                            cells_nodes[face_subcells[4]],
+                                            cells_nodes[face_subcells[5]],
+                                            cells_nodes[face_subcells[7]],
+                                            cells_nodes[face_subcells[6]],
+                                            cells_nodes[cell_subcells[0]],
+                                            cells_nodes[cell_subcells[1]],
+                                            cells_nodes[cell_subcells[3]],
+                                            cells_nodes[cell_subcells[2]],
+                                        ]);
+                                        connected_faces[4] = Some(face_cell_index)
+                                    }
+                                    2 | 3 | 5 => {}
+                                    _ => panic!(),
+                                }
+                            }
+                        }
+                    }
+                });
+            if let Some(face_4) = connected_faces[4] {
+                fa_4_subcells = tree[*face_4].get_cells().unwrap();
+            }
+            if let Some(face_1) = connected_faces[1] {
+                fa_1_subcells = tree[*face_1].get_cells().unwrap();
+                if connected_faces[4].is_some() {
+                    if let Some(diag_subcells) =
+                        tree[tree[*face_1].get_faces()[4].unwrap()].get_cells()
+                    {
+                        if tree.just_leaves(diag_subcells) {
+                            d_14_subcells = Some(diag_subcells);
+                        }
+                    }
+                }
+            }
+            if let Some(face_0) = connected_faces[0] {
+                fa_0_subcells = tree[*face_0].get_cells().unwrap();
+                face_0_faces = tree[*face_0].get_faces();
+                if connected_faces[1].is_some() {
+                    if let Some(diag_subcells) = tree[face_0_faces[1].unwrap()].get_cells() {
+                        if tree.just_leaves(diag_subcells) {
+                            d_01_subcells = Some(diag_subcells);
+                        }
+                    }
+                }
+                if connected_faces[4].is_some() {
+                    if let Some(diag_subcells) = tree[face_0_faces[4].unwrap()].get_cells() {
+                        if tree.just_leaves(diag_subcells) {
+                            d_04_subcells = Some(diag_subcells);
+                            if d_01_subcells.is_some() && d_01_subcells.is_some() {
+                                if let Some(diag_subcells_also) = tree
+                                    [tree[face_0_faces[1].unwrap()].get_faces()[4].unwrap()]
+                                .get_cells()
+                                {
+                                    if tree.just_leaves(diag_subcells_also) {
+                                        d014_subcells = Some(diag_subcells_also)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if let Some(diag_subcells) = d_01_subcells {
+                element_node_connectivity.push([
+                    cells_nodes[fa_0_subcells[3]],
+                    cells_nodes[diag_subcells[2]],
+                    cells_nodes[fa_1_subcells[0]],
+                    cells_nodes[cell_subcells[1]],
+                    cells_nodes[fa_0_subcells[7]],
+                    cells_nodes[diag_subcells[6]],
+                    cells_nodes[fa_1_subcells[4]],
+                    cells_nodes[cell_subcells[5]],
+                ]);
+            }
+            if let Some(diag_subcells) = d_04_subcells {
+                element_node_connectivity.push([
+                    cells_nodes[diag_subcells[6]],
+                    cells_nodes[diag_subcells[7]],
+                    cells_nodes[fa_4_subcells[5]],
+                    cells_nodes[fa_4_subcells[4]],
+                    cells_nodes[fa_0_subcells[2]],
+                    cells_nodes[fa_0_subcells[3]],
+                    cells_nodes[cell_subcells[1]],
+                    cells_nodes[cell_subcells[0]],
+                ]);
+            }
+            if let Some(d_14_subcells) = d_14_subcells {
+                element_node_connectivity.push([
+                    cells_nodes[fa_4_subcells[5]],
+                    cells_nodes[d_14_subcells[4]],
+                    cells_nodes[d_14_subcells[6]],
+                    cells_nodes[fa_4_subcells[7]],
+                    cells_nodes[cell_subcells[1]],
+                    cells_nodes[fa_1_subcells[0]],
+                    cells_nodes[fa_1_subcells[2]],
+                    cells_nodes[cell_subcells[3]],
+                ]);
+                if let Some(diag_subcells) = d014_subcells {
+                    element_node_connectivity.push([
+                        cells_nodes[d_04_subcells.unwrap()[7]],
+                        cells_nodes[diag_subcells[6]],
+                        cells_nodes[d_14_subcells[4]],
+                        cells_nodes[fa_4_subcells[5]],
+                        cells_nodes[fa_0_subcells[3]],
+                        cells_nodes[d_01_subcells.unwrap()[2]],
+                        cells_nodes[fa_1_subcells[0]],
+                        cells_nodes[cell_subcells[1]],
+                    ]);
+                }
+            }
+        });
+}

--- a/src/tree/hex/face_template_0/mod.rs
+++ b/src/tree/hex/face_template_0/mod.rs
@@ -1,7 +1,7 @@
 use super::super::{HexConnectivity, NUM_FACES, NUM_OCTANTS, Octree};
 
 pub fn apply(
-    cells_nodes: &Vec<usize>,
+    cells_nodes: &[usize],
     tree: &Octree,
     element_node_connectivity: &mut HexConnectivity,
 ) {

--- a/src/tree/hex/face_template_1/mod.rs
+++ b/src/tree/hex/face_template_1/mod.rs
@@ -1,0 +1,470 @@
+use super::super::{
+    Coordinate, Coordinates, HexConnectivity, NODE_NUMBERING_OFFSET, NUM_OCTANTS,
+    NUM_SUBCELLS_FACE, NodeMap, Octree, subcells_on_own_face,
+};
+use crate::Vector;
+use conspire::math::{TensorArray, TensorVec, tensor_rank_1};
+
+const SCALE_1: f64 = 0.5;
+
+pub fn apply(
+    cell_subcells: &[usize; NUM_OCTANTS],
+    cells_nodes: &Vec<usize>,
+    nodes_map: &mut NodeMap,
+    face_index: usize,
+    face_subsubcells: [usize; 16],
+    tree: &Octree,
+    element_node_connectivity: &mut HexConnectivity,
+    nodal_coordinates: &mut Coordinates,
+    node_index: &mut usize,
+) {
+    let cell_subcells_face_nodes = subcells_on_own_face(face_index)
+        .iter()
+        .map(|&index| cells_nodes[cell_subcells[index]])
+        .collect::<Vec<usize>>()
+        .try_into()
+        .unwrap();
+    let adjacent_exterior_nodes = [
+        cells_nodes[face_subsubcells[1]],
+        cells_nodes[face_subsubcells[4]],
+        cells_nodes[face_subsubcells[7]],
+        cells_nodes[face_subsubcells[13]],
+        cells_nodes[face_subsubcells[14]],
+        cells_nodes[face_subsubcells[11]],
+        cells_nodes[face_subsubcells[8]],
+        cells_nodes[face_subsubcells[2]],
+    ];
+    let adjacent_interior_nodes = [
+        cells_nodes[face_subsubcells[3]],
+        cells_nodes[face_subsubcells[6]],
+        cells_nodes[face_subsubcells[12]],
+        cells_nodes[face_subsubcells[9]],
+    ];
+    let (scale_1, scale_2) = translations(face_index, &face_subsubcells, &tree);
+    let interior_nodes = [
+        *node_index,
+        *node_index + 1,
+        *node_index + 2,
+        *node_index + 3,
+    ];
+    *node_index += 4;
+    adjacent_interior_nodes.iter().for_each(|foo_i| {
+        nodal_coordinates.push(&nodal_coordinates[foo_i - NODE_NUMBERING_OFFSET] + scale_1.clone())
+    });
+    let mut coordinates = Coordinate::zero();
+    let mut indices = (0, 0, 0);
+    let mut exterior_nodes = [0; 8];
+    adjacent_exterior_nodes
+        .iter()
+        .zip(exterior_nodes.iter_mut())
+        .for_each(|(adjacent_exterior_node_i, exterior_node_i)| {
+            coordinates = &nodal_coordinates[adjacent_exterior_node_i - NODE_NUMBERING_OFFSET]
+                + scale_2.clone();
+            indices = (
+                (2.0 * coordinates[0]) as usize,
+                (2.0 * coordinates[1]) as usize,
+                (2.0 * coordinates[2]) as usize,
+            );
+            if let Some(node_id) = nodes_map.get(&indices) {
+                *exterior_node_i = *node_id;
+            } else {
+                *exterior_node_i = *node_index;
+                nodal_coordinates.push(coordinates.clone());
+                nodes_map.insert(indices, *node_index);
+                *node_index += 1;
+            }
+        });
+    connectivity(
+        &cells_nodes,
+        cell_subcells_face_nodes,
+        face_index,
+        face_subsubcells,
+        interior_nodes,
+        exterior_nodes,
+        element_node_connectivity,
+    )
+}
+
+fn connectivity(
+    cells_nodes: &Vec<usize>,
+    cell_subcells_face_nodes: [usize; NUM_SUBCELLS_FACE],
+    face_index: usize,
+    face_subsubcells: [usize; 16],
+    interior_nodes: [usize; 4],
+    exterior_nodes: [usize; 8],
+    element_node_connectivity: &mut HexConnectivity,
+) {
+    match face_index {
+        2 | 3 | 4 => {
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                cells_nodes[face_subsubcells[3]],
+                cells_nodes[face_subsubcells[6]],
+                cells_nodes[face_subsubcells[12]],
+                cells_nodes[face_subsubcells[9]],
+                interior_nodes[0],
+                interior_nodes[1],
+                interior_nodes[2],
+                interior_nodes[3],
+            ]);
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                cells_nodes[face_subsubcells[1]],
+                cells_nodes[face_subsubcells[4]],
+                cells_nodes[face_subsubcells[6]],
+                cells_nodes[face_subsubcells[3]],
+                exterior_nodes[0],
+                exterior_nodes[1],
+                interior_nodes[1],
+                interior_nodes[0],
+            ]);
+            element_node_connectivity.push([
+                cells_nodes[face_subsubcells[6]],
+                cells_nodes[face_subsubcells[7]],
+                cells_nodes[face_subsubcells[13]],
+                cells_nodes[face_subsubcells[12]],
+                interior_nodes[1],
+                exterior_nodes[2],
+                exterior_nodes[3],
+                interior_nodes[2],
+            ]);
+            element_node_connectivity.push([
+                cells_nodes[face_subsubcells[9]],
+                cells_nodes[face_subsubcells[12]],
+                cells_nodes[face_subsubcells[14]],
+                cells_nodes[face_subsubcells[11]],
+                interior_nodes[3],
+                interior_nodes[2],
+                exterior_nodes[4],
+                exterior_nodes[5],
+            ]);
+            element_node_connectivity.push([
+                cells_nodes[face_subsubcells[2]],
+                cells_nodes[face_subsubcells[3]],
+                cells_nodes[face_subsubcells[9]],
+                cells_nodes[face_subsubcells[8]],
+                exterior_nodes[7],
+                interior_nodes[0],
+                interior_nodes[3],
+                exterior_nodes[6],
+            ]);
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                cells_nodes[face_subsubcells[0]],
+                cells_nodes[face_subsubcells[1]],
+                cells_nodes[face_subsubcells[3]],
+                cells_nodes[face_subsubcells[2]],
+                cell_subcells_face_nodes[0],
+                exterior_nodes[0],
+                interior_nodes[0],
+                exterior_nodes[7],
+            ]);
+            element_node_connectivity.push([
+                cells_nodes[face_subsubcells[4]],
+                cells_nodes[face_subsubcells[5]],
+                cells_nodes[face_subsubcells[7]],
+                cells_nodes[face_subsubcells[6]],
+                exterior_nodes[1],
+                cell_subcells_face_nodes[1],
+                exterior_nodes[2],
+                interior_nodes[1],
+            ]);
+            element_node_connectivity.push([
+                cells_nodes[face_subsubcells[12]],
+                cells_nodes[face_subsubcells[13]],
+                cells_nodes[face_subsubcells[15]],
+                cells_nodes[face_subsubcells[14]],
+                interior_nodes[2],
+                exterior_nodes[3],
+                cell_subcells_face_nodes[3],
+                exterior_nodes[4],
+            ]);
+            element_node_connectivity.push([
+                cells_nodes[face_subsubcells[8]],
+                cells_nodes[face_subsubcells[9]],
+                cells_nodes[face_subsubcells[11]],
+                cells_nodes[face_subsubcells[10]],
+                exterior_nodes[6],
+                interior_nodes[3],
+                exterior_nodes[5],
+                cell_subcells_face_nodes[2],
+            ]);
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                interior_nodes[0],
+                interior_nodes[1],
+                interior_nodes[2],
+                interior_nodes[3],
+                exterior_nodes[0],
+                exterior_nodes[1],
+                exterior_nodes[4],
+                exterior_nodes[5],
+            ]);
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                exterior_nodes[0],
+                exterior_nodes[1],
+                exterior_nodes[4],
+                exterior_nodes[5],
+                cell_subcells_face_nodes[0],
+                cell_subcells_face_nodes[1],
+                cell_subcells_face_nodes[3],
+                cell_subcells_face_nodes[2],
+            ]);
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                exterior_nodes[2],
+                exterior_nodes[3],
+                interior_nodes[2],
+                interior_nodes[1],
+                cell_subcells_face_nodes[1],
+                cell_subcells_face_nodes[3],
+                exterior_nodes[4],
+                exterior_nodes[1],
+            ]);
+            element_node_connectivity.push([
+                exterior_nodes[6],
+                exterior_nodes[7],
+                interior_nodes[0],
+                interior_nodes[3],
+                cell_subcells_face_nodes[2],
+                cell_subcells_face_nodes[0],
+                exterior_nodes[0],
+                exterior_nodes[5],
+            ]);
+        }
+        0 | 1 | 5 => {
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                interior_nodes[0],
+                interior_nodes[1],
+                interior_nodes[2],
+                interior_nodes[3],
+                cells_nodes[face_subsubcells[3]],
+                cells_nodes[face_subsubcells[6]],
+                cells_nodes[face_subsubcells[12]],
+                cells_nodes[face_subsubcells[9]],
+            ]);
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                exterior_nodes[0],
+                exterior_nodes[1],
+                interior_nodes[1],
+                interior_nodes[0],
+                cells_nodes[face_subsubcells[1]],
+                cells_nodes[face_subsubcells[4]],
+                cells_nodes[face_subsubcells[6]],
+                cells_nodes[face_subsubcells[3]],
+            ]);
+            element_node_connectivity.push([
+                interior_nodes[1],
+                exterior_nodes[2],
+                exterior_nodes[3],
+                interior_nodes[2],
+                cells_nodes[face_subsubcells[6]],
+                cells_nodes[face_subsubcells[7]],
+                cells_nodes[face_subsubcells[13]],
+                cells_nodes[face_subsubcells[12]],
+            ]);
+            element_node_connectivity.push([
+                interior_nodes[3],
+                interior_nodes[2],
+                exterior_nodes[4],
+                exterior_nodes[5],
+                cells_nodes[face_subsubcells[9]],
+                cells_nodes[face_subsubcells[12]],
+                cells_nodes[face_subsubcells[14]],
+                cells_nodes[face_subsubcells[11]],
+            ]);
+            element_node_connectivity.push([
+                exterior_nodes[7],
+                interior_nodes[0],
+                interior_nodes[3],
+                exterior_nodes[6],
+                cells_nodes[face_subsubcells[2]],
+                cells_nodes[face_subsubcells[3]],
+                cells_nodes[face_subsubcells[9]],
+                cells_nodes[face_subsubcells[8]],
+            ]);
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                cell_subcells_face_nodes[0],
+                exterior_nodes[0],
+                interior_nodes[0],
+                exterior_nodes[7],
+                cells_nodes[face_subsubcells[0]],
+                cells_nodes[face_subsubcells[1]],
+                cells_nodes[face_subsubcells[3]],
+                cells_nodes[face_subsubcells[2]],
+            ]);
+            element_node_connectivity.push([
+                exterior_nodes[1],
+                cell_subcells_face_nodes[1],
+                exterior_nodes[2],
+                interior_nodes[1],
+                cells_nodes[face_subsubcells[4]],
+                cells_nodes[face_subsubcells[5]],
+                cells_nodes[face_subsubcells[7]],
+                cells_nodes[face_subsubcells[6]],
+            ]);
+            element_node_connectivity.push([
+                interior_nodes[2],
+                exterior_nodes[3],
+                cell_subcells_face_nodes[3],
+                exterior_nodes[4],
+                cells_nodes[face_subsubcells[12]],
+                cells_nodes[face_subsubcells[13]],
+                cells_nodes[face_subsubcells[15]],
+                cells_nodes[face_subsubcells[14]],
+            ]);
+            element_node_connectivity.push([
+                exterior_nodes[6],
+                interior_nodes[3],
+                exterior_nodes[5],
+                cell_subcells_face_nodes[2],
+                cells_nodes[face_subsubcells[8]],
+                cells_nodes[face_subsubcells[9]],
+                cells_nodes[face_subsubcells[11]],
+                cells_nodes[face_subsubcells[10]],
+            ]);
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                exterior_nodes[0],
+                exterior_nodes[1],
+                exterior_nodes[4],
+                exterior_nodes[5],
+                interior_nodes[0],
+                interior_nodes[1],
+                interior_nodes[2],
+                interior_nodes[3],
+            ]);
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                cell_subcells_face_nodes[0],
+                cell_subcells_face_nodes[1],
+                cell_subcells_face_nodes[3],
+                cell_subcells_face_nodes[2],
+                exterior_nodes[0],
+                exterior_nodes[1],
+                exterior_nodes[4],
+                exterior_nodes[5],
+            ]);
+            //
+            // next type
+            //
+            element_node_connectivity.push([
+                cell_subcells_face_nodes[1],
+                cell_subcells_face_nodes[3],
+                exterior_nodes[4],
+                exterior_nodes[1],
+                exterior_nodes[2],
+                exterior_nodes[3],
+                interior_nodes[2],
+                interior_nodes[1],
+            ]);
+            element_node_connectivity.push([
+                cell_subcells_face_nodes[2],
+                cell_subcells_face_nodes[0],
+                exterior_nodes[0],
+                exterior_nodes[5],
+                exterior_nodes[6],
+                exterior_nodes[7],
+                interior_nodes[0],
+                interior_nodes[3],
+            ]);
+        }
+        _ => panic!(),
+    }
+}
+
+fn translations(
+    face_index: usize,
+    face_subsubcells: &[usize; 16],
+    tree: &Octree,
+) -> (Vector, Vector) {
+    match face_index {
+        0 => (
+            tensor_rank_1([
+                0.0,
+                SCALE_1 * *tree[face_subsubcells[0]].get_lngth() as f64,
+                0.0,
+            ]),
+            tensor_rank_1([0.0, *tree[face_subsubcells[0]].get_lngth() as f64, 0.0]),
+        ),
+        1 => (
+            tensor_rank_1([
+                -SCALE_1 * *tree[face_subsubcells[0]].get_lngth() as f64,
+                0.0,
+                0.0,
+            ]),
+            tensor_rank_1([
+                -1.0 * *tree[face_subsubcells[0]].get_lngth() as f64,
+                0.0,
+                0.0,
+            ]),
+        ),
+        2 => (
+            tensor_rank_1([
+                0.0,
+                -SCALE_1 * *tree[face_subsubcells[0]].get_lngth() as f64,
+                0.0,
+            ]),
+            tensor_rank_1([
+                0.0,
+                -1.0 * *tree[face_subsubcells[0]].get_lngth() as f64,
+                0.0,
+            ]),
+        ),
+        3 => (
+            tensor_rank_1([
+                SCALE_1 * *tree[face_subsubcells[0]].get_lngth() as f64,
+                0.0,
+                0.0,
+            ]),
+            tensor_rank_1([*tree[face_subsubcells[0]].get_lngth() as f64, 0.0, 0.0]),
+        ),
+        4 => (
+            tensor_rank_1([
+                0.0,
+                0.0,
+                SCALE_1 * *tree[face_subsubcells[0]].get_lngth() as f64,
+            ]),
+            tensor_rank_1([0.0, 0.0, *tree[face_subsubcells[0]].get_lngth() as f64]),
+        ),
+        5 => (
+            tensor_rank_1([
+                0.0,
+                0.0,
+                -SCALE_1 * *tree[face_subsubcells[0]].get_lngth() as f64,
+            ]),
+            tensor_rank_1([
+                0.0,
+                0.0,
+                -1.0 * *tree[face_subsubcells[0]].get_lngth() as f64,
+            ]),
+        ),
+        _ => panic!(),
+    }
+}

--- a/src/tree/hex/mod.rs
+++ b/src/tree/hex/mod.rs
@@ -1,0 +1,3 @@
+pub mod edge_template_1;
+pub mod face_template_0;
+pub mod face_template_1;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "profile")]
 use std::time::Instant;
 
+mod hex;
 mod tet;
 
 use super::{
@@ -15,6 +16,7 @@ use conspire::math::{TensorArray, TensorRank1Vec, TensorVec};
 use ndarray::{Axis, parallel::prelude::*, s};
 use std::{
     array::from_fn,
+    collections::HashMap,
     ops::{Deref, DerefMut},
 };
 
@@ -112,6 +114,7 @@ type Edge = [usize; 2];
 type Edges = Vec<Edge>;
 type Faces = [Option<usize>; NUM_FACES];
 type Indices = [usize; NUM_OCTANTS];
+type NodeMap = HashMap<(usize, usize, usize), usize>;
 
 /// The octree type.
 pub struct Octree {
@@ -325,6 +328,9 @@ impl Cell {
     }
     pub fn is_leaf(&self) -> bool {
         self.get_cells().is_none()
+    }
+    pub fn is_not_leaf(&self) -> bool {
+        !self.get_cells().is_none()
     }
     pub fn is_voxel(&self) -> bool {
         self.lngth == 1
@@ -2040,48 +2046,40 @@ fn non_manifold(faces_connectivity: &[[usize; 4]], node_face_connectivity: &[Vec
 
 impl From<Octree> for HexahedralFiniteElements {
     fn from(tree: Octree) -> Self {
-        //
-        // Eventually check the efficiency of parallelization here,
-        // but keep in mind the real overall bottlenecks.
-        //
         #[cfg(feature = "profile")]
         let time = Instant::now();
         let mut nodal_coordinates = Coordinates::zero(0);
+        //
+        // might be better to have 2 maps
+        // (1) give it leaf, gives you node at center
+        // (2) the odd created nodes
+        // since will have queried cells for (1) usually when need those nodes
+        //
+        let mut nodes_map = HashMap::new();
         let mut cells_nodes = vec![0; tree.len()];
         let mut node_index = NODE_NUMBERING_OFFSET;
+        let mut tx = 0;
+        let mut ty = 0;
+        let mut tz = 0;
         tree.iter()
             .enumerate()
             .filter(|(_, cell)| cell.is_leaf())
             .for_each(|(leaf_index, leaf)| {
                 cells_nodes[leaf_index] = node_index;
+                tx = 2 * leaf.get_min_x() + leaf.get_lngth();
+                ty = 2 * leaf.get_min_y() + leaf.get_lngth();
+                tz = 2 * leaf.get_min_z() + leaf.get_lngth();
                 nodal_coordinates.append(&mut TensorRank1Vec::new(&[[
-                    0.5 * (2 * leaf.get_min_x() + leaf.get_lngth()) as f64 * tree.scale.x()
-                        + tree.translate.x(),
-                    0.5 * (2 * leaf.get_min_y() + leaf.get_lngth()) as f64 * tree.scale.y()
-                        + tree.translate.y(),
-                    0.5 * (2 * leaf.get_min_z() + leaf.get_lngth()) as f64 * tree.scale.z()
-                        + tree.translate.z(),
+                    0.5 * tx as f64 * tree.scale.x() + tree.translate.x(),
+                    0.5 * ty as f64 * tree.scale.y() + tree.translate.y(),
+                    0.5 * tz as f64 * tree.scale.z() + tree.translate.z(),
                 ]]));
+                // nodes_map.insert((tx.into(), ty.into(), tz.into()), node_index);
                 node_index += 1;
             });
-        let mut connected_faces = [None; NUM_FACES];
-        let mut d_01_subcells = None;
-        let mut d_04_subcells = None;
-        let mut d_14_subcells = None;
-        let mut d014_subcells = None;
-        let mut fa_0_subcells = [0; NUM_OCTANTS];
-        let mut fa_1_subcells = [0; NUM_OCTANTS];
-        let mut fa_4_subcells = [0; NUM_OCTANTS];
-        let mut face_0_faces = &[None; NUM_FACES];
-        //
-        // Split some of this up?
-        // Loop 0: hex in each cell containing only leaves.
-        // Loop 1: transition 1, single hexes between similar adjacent hexes.
-        // Loop 2: transition 2, the wineglass transition.
-        // ...
-        //
         let mut element_node_connectivity: HexConnectivity = tree
-            .par_iter()
+            // .par_iter()
+            .iter()
             .filter_map(|cell| tree.cell_contains_leaves(cell))
             .map(|(cell_subcells, _)| {
                 [
@@ -2096,465 +2094,54 @@ impl From<Octree> for HexahedralFiniteElements {
                 ]
             })
             .collect();
-        //
-        // Might be able to return the new connectivities from the closure in parallel and then append them afterwards.
-        //
-        tree.iter()
-            .filter_map(|cell| tree.cell_contains_leaves(cell))
-            .for_each(|(cell_subcells, cell_faces)| {
-                connected_faces = [None; NUM_FACES];
-                d_01_subcells = None;
-                d_04_subcells = None;
-                d_14_subcells = None;
-                d014_subcells = None;
-                cell_faces
-                    .iter()
-                    .enumerate()
-                    .for_each(|(face_index, face_cell)| {
-                        if let Some(face_cell_index) = face_cell {
-                            if let Some(face_subcells) = tree[*face_cell_index].get_cells() {
-                                if tree.just_leaves(face_subcells) {
-                                    match face_index {
-                                        0 => {
-                                            element_node_connectivity.push([
-                                                cells_nodes[face_subcells[2]],
-                                                cells_nodes[face_subcells[3]],
-                                                cells_nodes[cell_subcells[1]],
-                                                cells_nodes[cell_subcells[0]],
-                                                cells_nodes[face_subcells[6]],
-                                                cells_nodes[face_subcells[7]],
-                                                cells_nodes[cell_subcells[5]],
-                                                cells_nodes[cell_subcells[4]],
-                                            ]);
-                                            connected_faces[0] = Some(face_cell_index)
-                                        }
-                                        1 => {
-                                            element_node_connectivity.push([
-                                                cells_nodes[cell_subcells[1]],
-                                                cells_nodes[face_subcells[0]],
-                                                cells_nodes[face_subcells[2]],
-                                                cells_nodes[cell_subcells[3]],
-                                                cells_nodes[cell_subcells[5]],
-                                                cells_nodes[face_subcells[4]],
-                                                cells_nodes[face_subcells[6]],
-                                                cells_nodes[cell_subcells[7]],
-                                            ]);
-                                            connected_faces[1] = Some(face_cell_index)
-                                        }
-                                        4 => {
-                                            element_node_connectivity.push([
-                                                cells_nodes[face_subcells[4]],
-                                                cells_nodes[face_subcells[5]],
-                                                cells_nodes[face_subcells[7]],
-                                                cells_nodes[face_subcells[6]],
-                                                cells_nodes[cell_subcells[0]],
-                                                cells_nodes[cell_subcells[1]],
-                                                cells_nodes[cell_subcells[3]],
-                                                cells_nodes[cell_subcells[2]],
-                                            ]);
-                                            connected_faces[4] = Some(face_cell_index)
-                                        }
-                                        2 | 3 | 5 => {}
-                                        _ => panic!(),
-                                    }
-                                }
-                            }
-                        }
-                    });
-                if let Some(face_4) = connected_faces[4] {
-                    fa_4_subcells = tree[*face_4].get_cells().unwrap();
-                }
-                if let Some(face_1) = connected_faces[1] {
-                    fa_1_subcells = tree[*face_1].get_cells().unwrap();
-                    if connected_faces[4].is_some() {
-                        if let Some(diag_subcells) =
-                            tree[tree[*face_1].get_faces()[4].unwrap()].get_cells()
-                        {
-                            if tree.just_leaves(diag_subcells) {
-                                d_14_subcells = Some(diag_subcells);
-                            }
-                        }
-                    }
-                }
-                if let Some(face_0) = connected_faces[0] {
-                    fa_0_subcells = tree[*face_0].get_cells().unwrap();
-                    face_0_faces = tree[*face_0].get_faces();
-                    if connected_faces[1].is_some() {
-                        if let Some(diag_subcells) = tree[face_0_faces[1].unwrap()].get_cells() {
-                            if tree.just_leaves(diag_subcells) {
-                                d_01_subcells = Some(diag_subcells);
-                            }
-                        }
-                    }
-                    if connected_faces[4].is_some() {
-                        if let Some(diag_subcells) = tree[face_0_faces[4].unwrap()].get_cells() {
-                            if tree.just_leaves(diag_subcells) {
-                                d_04_subcells = Some(diag_subcells);
-                                if d_01_subcells.is_some() && d_01_subcells.is_some() {
-                                    if let Some(diag_subcells_also) = tree
-                                        [tree[face_0_faces[1].unwrap()].get_faces()[4].unwrap()]
-                                    .get_cells()
-                                    {
-                                        if tree.just_leaves(diag_subcells_also) {
-                                            d014_subcells = Some(diag_subcells_also)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                if let Some(diag_subcells) = d_01_subcells {
-                    element_node_connectivity.push([
-                        cells_nodes[fa_0_subcells[3]],
-                        cells_nodes[diag_subcells[2]],
-                        cells_nodes[fa_1_subcells[0]],
-                        cells_nodes[cell_subcells[1]],
-                        cells_nodes[fa_0_subcells[7]],
-                        cells_nodes[diag_subcells[6]],
-                        cells_nodes[fa_1_subcells[4]],
-                        cells_nodes[cell_subcells[5]],
-                    ]);
-                }
-                if let Some(diag_subcells) = d_04_subcells {
-                    element_node_connectivity.push([
-                        cells_nodes[diag_subcells[6]],
-                        cells_nodes[diag_subcells[7]],
-                        cells_nodes[fa_4_subcells[5]],
-                        cells_nodes[fa_4_subcells[4]],
-                        cells_nodes[fa_0_subcells[2]],
-                        cells_nodes[fa_0_subcells[3]],
-                        cells_nodes[cell_subcells[1]],
-                        cells_nodes[cell_subcells[0]],
-                    ]);
-                }
-                if let Some(d_14_subcells) = d_14_subcells {
-                    element_node_connectivity.push([
-                        cells_nodes[fa_4_subcells[5]],
-                        cells_nodes[d_14_subcells[4]],
-                        cells_nodes[d_14_subcells[6]],
-                        cells_nodes[fa_4_subcells[7]],
-                        cells_nodes[cell_subcells[1]],
-                        cells_nodes[fa_1_subcells[0]],
-                        cells_nodes[fa_1_subcells[2]],
-                        cells_nodes[cell_subcells[3]],
-                    ]);
-                    if let Some(diag_subcells) = d014_subcells {
-                        element_node_connectivity.push([
-                            cells_nodes[d_04_subcells.unwrap()[7]],
-                            cells_nodes[diag_subcells[6]],
-                            cells_nodes[d_14_subcells[4]],
-                            cells_nodes[fa_4_subcells[5]],
-                            cells_nodes[fa_0_subcells[3]],
-                            cells_nodes[d_01_subcells.unwrap()[2]],
-                            cells_nodes[fa_1_subcells[0]],
-                            cells_nodes[cell_subcells[1]],
-                        ]);
-                    }
-                }
-            });
-        //
-        // How to merge together these templates when they meet at 90 degrees?
-        // Could be helpful: exterior nodes (using current scale_2) are integer coordinates.
-        // So you can pre-populate and overwrite it like you would for tets.
-        //
-        // This will come up again for other templates.
-        // Will the overlapping nodes always have integer coordinates?
-        // Can you pre-populate them beforehand and avoid writing/overwriting?
-        //
-        let mut cell_subcells_face_nodes = [0; NUM_SUBCELLS_FACE];
-        tree.iter()
-            // tree.par_iter()
-            .filter_map(|cell| tree.cell_contains_leaves(cell))
-            .for_each(|(cell_subcells, cell_faces)| {
-                cell_faces
-                    .iter()
-                    .enumerate()
-                    .for_each(|(face_index, face_cell)| {
-                        if let Some(face_cell_index) = face_cell {
-                            if let Some((_, face_subsubcells)) = tree.cell_subcells_contain_leaves(
-                                &tree[*face_cell_index],
-                                0,
-                                face_index,
-                            ) {
-                                if face_index == 2 || face_index == 3 || face_index == 4 {
-                                    cell_subcells_face_nodes = subcells_on_own_face(face_index)
-                                        .iter()
-                                        .map(|&index| cells_nodes[cell_subcells[index]])
-                                        .collect::<Vec<usize>>()
-                                        .try_into()
-                                        .unwrap();
-                                    let adjacent_interior_nodes = [
-                                        cells_nodes[face_subsubcells[3]],
-                                        cells_nodes[face_subsubcells[6]],
-                                        cells_nodes[face_subsubcells[12]],
-                                        cells_nodes[face_subsubcells[9]],
-                                    ];
-                                    //
-                                    // Why are there uninitialized cells/hexes/etc. being hit?
-                                    //
-                                    if adjacent_interior_nodes.iter().all(|bar| bar != &0) {
-                                        let adjacent_exterior_nodes = //if face_index == 4 {
-                                            [
-                                                cells_nodes[face_subsubcells[1]],
-                                                cells_nodes[face_subsubcells[4]],
-                                                cells_nodes[face_subsubcells[7]],
-                                                cells_nodes[face_subsubcells[13]],
-                                                cells_nodes[face_subsubcells[14]],
-                                                cells_nodes[face_subsubcells[11]],
-                                                cells_nodes[face_subsubcells[8]],
-                                                cells_nodes[face_subsubcells[2]],
-                                            ];
-                                        // } else if face_index == 2 {
-                                        //     [
-                                        //         cells_nodes[face_subsubcells[1]],
-                                        //         cells_nodes[face_subsubcells[4]],
-                                        //         cells_nodes[face_subsubcells[7]],
-                                        //         cells_nodes[face_subsubcells[13]],
-                                        //         cells_nodes[face_subsubcells[14]],
-                                        //         cells_nodes[face_subsubcells[11]],
-                                        //         cells_nodes[face_subsubcells[8]],
-                                        //         cells_nodes[face_subsubcells[2]],
-                                        //     ]
-                                        // } else {
-                                        //     panic!()
-                                        // };
-                                        //
-                                        // BOTH SCALES ARE WHAT YOU CAN EVENTUALLY pre-OPTIMIZE AGAINST
-                                        //
-                                        let (scale_1, scale_2) = if face_index == 2 {
-                                            (
-                                                Coordinate::new([
-                                                    0.0,
-                                                    -0.5 * *tree[face_subsubcells[0]].get_lngth()
-                                                        as f64,
-                                                    0.0,
-                                                ]),
-                                                Coordinate::new([
-                                                    0.0,
-                                                    -1.0 * *tree[face_subsubcells[0]].get_lngth()
-                                                        as f64,
-                                                    0.0,
-                                                ]),
-                                            )
-                                        } else if face_index == 3 {
-                                            (
-                                                Coordinate::new([
-                                                    0.5 * *tree[face_subsubcells[0]].get_lngth()
-                                                        as f64,
-                                                    0.0,
-                                                    0.0,
-                                                ]),
-                                                Coordinate::new([
-                                                    1.0 * *tree[face_subsubcells[0]].get_lngth()
-                                                        as f64,
-                                                    0.0,
-                                                    0.0,
-                                                ]),
-                                            )
-                                        } else if face_index == 4 {
-                                            (
-                                                Coordinate::new([
-                                                    0.0,
-                                                    0.0,
-                                                    0.5 * *tree[face_subsubcells[0]].get_lngth()
-                                                        as f64,
-                                                ]),
-                                                Coordinate::new([
-                                                    0.0,
-                                                    0.0,
-                                                    1.0 * *tree[face_subsubcells[0]].get_lngth()
-                                                        as f64,
-                                                ]),
-                                            )
-                                        } else {
-                                            panic!()
-                                        };
-                                        let interior_nodes = [
-                                            node_index + 0,
-                                            node_index + 1,
-                                            node_index + 2,
-                                            node_index + 3,
-                                        ];
-                                        let exterior_nodes = [
-                                            node_index + 4,
-                                            node_index + 5,
-                                            node_index + 6,
-                                            node_index + 7,
-                                            node_index + 8,
-                                            node_index + 9,
-                                            node_index + 10,
-                                            node_index + 11,
-                                        ];
-                                        node_index += 12;
-                                        adjacent_interior_nodes.iter().for_each(|foo_i| {
-                                            nodal_coordinates.push(
-                                                &nodal_coordinates[foo_i - NODE_NUMBERING_OFFSET]
-                                                    + scale_1.clone(),
-                                            )
-                                        });
-                                        adjacent_exterior_nodes.iter().for_each(|foo_i| {
-                                            nodal_coordinates.push(
-                                                &nodal_coordinates[foo_i - NODE_NUMBERING_OFFSET]
-                                                    + scale_2.clone(),
-                                            )
-                                        });
-                                        //
-                                        // next type
-                                        //
-                                        element_node_connectivity.push([
-                                            cells_nodes[face_subsubcells[3]],
-                                            cells_nodes[face_subsubcells[6]],
-                                            cells_nodes[face_subsubcells[12]],
-                                            cells_nodes[face_subsubcells[9]],
-                                            interior_nodes[0],
-                                            interior_nodes[1],
-                                            interior_nodes[2],
-                                            interior_nodes[3],
-                                        ]);
-                                        //
-                                        // next type
-                                        //
-                                        element_node_connectivity.push([
-                                            cells_nodes[face_subsubcells[1]],
-                                            cells_nodes[face_subsubcells[4]],
-                                            cells_nodes[face_subsubcells[6]],
-                                            cells_nodes[face_subsubcells[3]],
-                                            exterior_nodes[0],
-                                            exterior_nodes[1],
-                                            interior_nodes[1],
-                                            interior_nodes[0],
-                                        ]);
-                                        element_node_connectivity.push([
-                                            cells_nodes[face_subsubcells[6]],
-                                            cells_nodes[face_subsubcells[7]],
-                                            cells_nodes[face_subsubcells[13]],
-                                            cells_nodes[face_subsubcells[12]],
-                                            interior_nodes[1],
-                                            exterior_nodes[2],
-                                            exterior_nodes[3],
-                                            interior_nodes[2],
-                                        ]);
-                                        element_node_connectivity.push([
-                                            cells_nodes[face_subsubcells[9]],
-                                            cells_nodes[face_subsubcells[12]],
-                                            cells_nodes[face_subsubcells[14]],
-                                            cells_nodes[face_subsubcells[11]],
-                                            interior_nodes[3],
-                                            interior_nodes[2],
-                                            exterior_nodes[4],
-                                            exterior_nodes[5],
-                                        ]);
-                                        element_node_connectivity.push([
-                                            cells_nodes[face_subsubcells[2]],
-                                            cells_nodes[face_subsubcells[3]],
-                                            cells_nodes[face_subsubcells[9]],
-                                            cells_nodes[face_subsubcells[8]],
-                                            exterior_nodes[7],
-                                            interior_nodes[0],
-                                            interior_nodes[3],
-                                            exterior_nodes[6],
-                                        ]);
-                                        //
-                                        // next type
-                                        //
-                                        element_node_connectivity.push([
-                                            cells_nodes[face_subsubcells[0]],
-                                            cells_nodes[face_subsubcells[1]],
-                                            cells_nodes[face_subsubcells[3]],
-                                            cells_nodes[face_subsubcells[2]],
-                                            cell_subcells_face_nodes[0],
-                                            exterior_nodes[0],
-                                            interior_nodes[0],
-                                            exterior_nodes[7],
-                                        ]);
-                                        element_node_connectivity.push([
-                                            cells_nodes[face_subsubcells[4]],
-                                            cells_nodes[face_subsubcells[5]],
-                                            cells_nodes[face_subsubcells[7]],
-                                            cells_nodes[face_subsubcells[6]],
-                                            exterior_nodes[1],
-                                            cell_subcells_face_nodes[1],
-                                            exterior_nodes[2],
-                                            interior_nodes[1],
-                                        ]);
-                                        element_node_connectivity.push([
-                                            cells_nodes[face_subsubcells[12]],
-                                            cells_nodes[face_subsubcells[13]],
-                                            cells_nodes[face_subsubcells[15]],
-                                            cells_nodes[face_subsubcells[14]],
-                                            interior_nodes[2],
-                                            exterior_nodes[3],
-                                            cell_subcells_face_nodes[3],
-                                            exterior_nodes[4],
-                                        ]);
-                                        element_node_connectivity.push([
-                                            cells_nodes[face_subsubcells[8]],
-                                            cells_nodes[face_subsubcells[9]],
-                                            cells_nodes[face_subsubcells[11]],
-                                            cells_nodes[face_subsubcells[10]],
-                                            exterior_nodes[6],
-                                            interior_nodes[3],
-                                            exterior_nodes[5],
-                                            cell_subcells_face_nodes[2],
-                                        ]);
-                                        //
-                                        // next type
-                                        //
-                                        element_node_connectivity.push([
-                                            interior_nodes[0],
-                                            interior_nodes[1],
-                                            interior_nodes[2],
-                                            interior_nodes[3],
-                                            exterior_nodes[0],
-                                            exterior_nodes[1],
-                                            exterior_nodes[4],
-                                            exterior_nodes[5],
-                                        ]);
-                                        //
-                                        // next type
-                                        //
-                                        element_node_connectivity.push([
-                                            exterior_nodes[0],
-                                            exterior_nodes[1],
-                                            exterior_nodes[4],
-                                            exterior_nodes[5],
-                                            cell_subcells_face_nodes[0],
-                                            cell_subcells_face_nodes[1],
-                                            cell_subcells_face_nodes[3],
-                                            cell_subcells_face_nodes[2],
-                                        ]);
-                                        //
-                                        // next type
-                                        //
-                                        element_node_connectivity.push([
-                                            exterior_nodes[2],
-                                            exterior_nodes[3],
-                                            interior_nodes[2],
-                                            interior_nodes[1],
-                                            cell_subcells_face_nodes[1],
-                                            cell_subcells_face_nodes[3],
-                                            exterior_nodes[4],
-                                            exterior_nodes[1],
-                                        ]);
-                                        element_node_connectivity.push([
-                                            exterior_nodes[6],
-                                            exterior_nodes[7],
-                                            interior_nodes[0],
-                                            interior_nodes[3],
-                                            cell_subcells_face_nodes[2],
-                                            cell_subcells_face_nodes[0],
-                                            exterior_nodes[0],
-                                            exterior_nodes[5],
-                                        ]);
-                                    }
-                                }
-                                // want the 16 cell nodes on the particular face
-                                // if keep them in a particular order (similarly the 4 cell nodes) can send straight to template?
-                            }
-                        }
-                    })
-            });
+        hex::face_template_0::apply(&cells_nodes, &tree, &mut element_node_connectivity);
+        hex::edge_template_1::apply(
+            &cells_nodes,
+            &mut nodes_map,
+            &mut node_index,
+            &tree,
+            &mut element_node_connectivity,
+            &mut nodal_coordinates,
+        );
+        // tree.iter()
+        //     .filter_map(|cell| tree.cell_contains_leaves(cell))
+        //     .for_each(|(cell_subcells, cell_faces)| {
+        //         cell_faces
+        //             .iter()
+        //             .enumerate()
+        //             .for_each(|(face_index, face_cell)| {
+        //                 if let Some(face_cell_index) = face_cell {
+        //                     if let Some((_, face_subsubcells)) = tree.cell_subcells_contain_leaves(
+        //                         &tree[*face_cell_index],
+        //                         0,
+        //                         face_index,
+        //                     ) {
+        //                         //
+        //                         // Why are there uninitialized cells/hexes/etc. being hit?
+        //                         //
+        //                         let foo = [
+        //                             cells_nodes[face_subsubcells[3]],
+        //                             cells_nodes[face_subsubcells[6]],
+        //                             cells_nodes[face_subsubcells[12]],
+        //                             cells_nodes[face_subsubcells[9]],
+        //                         ];
+        //                         if foo.iter().all(|bar| bar != &0) {
+        //                             hex::face_template_1::apply(
+        //                                 cell_subcells,
+        //                                 &cells_nodes,
+        //                                 &mut nodes_map,
+        //                                 face_index,
+        //                                 face_subsubcells,
+        //                                 &tree,
+        //                                 &mut element_node_connectivity,
+        //                                 &mut nodal_coordinates,
+        //                                 &mut node_index,
+        //                             )
+        //                         }
+        //                     }
+        //                 }
+        //             })
+        //     });
         let fem = Self::from_data(
             vec![1; element_node_connectivity.len()],
             element_node_connectivity,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -2326,32 +2326,28 @@ impl From<Octree> for HexahedralFiniteElements {
                                             (
                                                 Coordinate::new([
                                                     0.0,
-                                                    -0.5
-                                                        * *tree[face_subsubcells[0]].get_lngth()
-                                                            as f64,
+                                                    -0.5 * *tree[face_subsubcells[0]].get_lngth()
+                                                        as f64,
                                                     0.0,
                                                 ]),
                                                 Coordinate::new([
                                                     0.0,
-                                                    -1.0
-                                                        * *tree[face_subsubcells[0]].get_lngth()
-                                                            as f64,
+                                                    -1.0 * *tree[face_subsubcells[0]].get_lngth()
+                                                        as f64,
                                                     0.0,
                                                 ]),
                                             )
                                         } else if face_index == 3 {
                                             (
                                                 Coordinate::new([
-                                                    0.5
-                                                        * *tree[face_subsubcells[0]].get_lngth()
-                                                            as f64,
+                                                    0.5 * *tree[face_subsubcells[0]].get_lngth()
+                                                        as f64,
                                                     0.0,
                                                     0.0,
                                                 ]),
                                                 Coordinate::new([
-                                                    1.0
-                                                        * *tree[face_subsubcells[0]].get_lngth()
-                                                            as f64,
+                                                    1.0 * *tree[face_subsubcells[0]].get_lngth()
+                                                        as f64,
                                                     0.0,
                                                     0.0,
                                                 ]),
@@ -2361,16 +2357,14 @@ impl From<Octree> for HexahedralFiniteElements {
                                                 Coordinate::new([
                                                     0.0,
                                                     0.0,
-                                                    0.5
-                                                        * *tree[face_subsubcells[0]].get_lngth()
-                                                            as f64,
+                                                    0.5 * *tree[face_subsubcells[0]].get_lngth()
+                                                        as f64,
                                                 ]),
                                                 Coordinate::new([
                                                     0.0,
                                                     0.0,
-                                                    1.0
-                                                        * *tree[face_subsubcells[0]].get_lngth()
-                                                            as f64,
+                                                    1.0 * *tree[face_subsubcells[0]].get_lngth()
+                                                        as f64,
                                                 ]),
                                             )
                                         } else {

--- a/src/tree/tet/mod.rs
+++ b/src/tree/tet/mod.rs
@@ -3,7 +3,7 @@ use super::{
         Connectivity,
         tet::{NUM_TETS_PER_HEX, TET, TetrahedralFiniteElements, TetrahedralTransition},
     },
-    Blocks, Cell, NODE_NUMBERING_OFFSET, Neighbor, Octree, Tree,
+    Blocks, Cell, NODE_NUMBERING_OFFSET, Neighbor, Octree,
 };
 
 pub fn connectivity(

--- a/src/voxel/mod.rs
+++ b/src/voxel/mod.rs
@@ -10,7 +10,7 @@ use std::time::Instant;
 use crate::TetrahedralFiniteElements;
 
 use super::{
-    Coordinate, Coordinates, NSD, Octree, Tree, Vector,
+    Coordinate, Coordinates, NSD, Octree, Vector,
     fem::{
         Blocks, Connectivity, FiniteElementMethods, HEX, HexahedralFiniteElements,
         NODE_NUMBERING_OFFSET,

--- a/tests/affine.rs
+++ b/tests/affine.rs
@@ -1,6 +1,5 @@
 use automesh::{
-    FiniteElementMethods, NODE_NUMBERING_OFFSET, Octree, TET, TetrahedralFiniteElements,
-    Voxels,
+    FiniteElementMethods, NODE_NUMBERING_OFFSET, Octree, TET, TetrahedralFiniteElements, Voxels,
 };
 use conspire::{
     constitutive::{

--- a/tests/affine.rs
+++ b/tests/affine.rs
@@ -1,5 +1,5 @@
 use automesh::{
-    FiniteElementMethods, NODE_NUMBERING_OFFSET, Octree, TET, TetrahedralFiniteElements, Tree,
+    FiniteElementMethods, NODE_NUMBERING_OFFSET, Octree, TET, TetrahedralFiniteElements,
     Voxels,
 };
 use conspire::{


### PR DESCRIPTION
@hovey this is the first set of dualization templates and a proof of concept.

It inserts a hex at the center of every octree containing leafs, has 2 of 2 face-based transition templates,
- transition across face of octrees of the same refinement (trivial; one hex)
- transition across face with one level of refinement (wineglass type)
and has 1 of 4 edge-based transition templates
- corner meets 1 level of refinement on either face

The regular hexes and 2 face templates make up most of the hexes I thinkl, so we can start to estimate performance. Below is the resolution 4 sphere, it takes just under half a second and generates ~650k elements. The recent paper takes several hundred (or even thousand) seconds for 30k-300k elements. The paper has 2 more steps that we do not yet (projecting to STL surface and internal smoothing) but so far it seems like we should several hundred or thousand times faster, maybe even close to ten thousand times faster (and they are seemingly an order of magnitude faster than the papers they compare to), which is unbelievable.

Element count reduction depends on segmentation size. For the case below, it only cuts it in half. For a more refined case (sphere resolution 16), it cuts it by almost 90%. So the method does better as the segmentation is refined, which is great. I am guessing we will see better ratios when we eventually get to smooth surfaces since we can get away with larger elements along the surface than voxels. It also should improve if we ever get to weak balancing or the ILP-driven pairing (I guess a template-based approach for either case would be novel).

![Screenshot from 2025-06-17 12-39-07](https://github.com/user-attachments/assets/823cfe62-75a9-46d6-8ad7-71b5261aeadb)
![Screenshot from 2025-06-17 12-39-04](https://github.com/user-attachments/assets/21a7fe1d-7640-410e-8000-dd73c9d41c2e)
![Screenshot from 2025-06-17 12-39-30](https://github.com/user-attachments/assets/44f72836-5474-42ca-b62a-c1241090a909)

![IMG_0241](https://github.com/user-attachments/assets/651f4bd5-92c4-4f6c-84ec-6879d5e52467)
![IMG_0243](https://github.com/user-attachments/assets/48f8efea-7fb3-4277-b0e0-60ad893357c4)
![IMG_0242](https://github.com/user-attachments/assets/8cfc1e7f-b77b-481d-957d-9737168a0876)
