### PR TITLE
dualization

### DIFF
--- a/src/tree/hex/edge_template_1/mod.rs
+++ b/src/tree/hex/edge_template_1/mod.rs
@@ -1,7 +1,7 @@
 use super::super::{
-    Coordinates, HexConnectivity, NODE_NUMBERING_OFFSET, NUM_OCTANTS, NodeMap, Octree,
+    Cell, Coordinates, HexConnectivity, NODE_NUMBERING_OFFSET, NodeMap, Octree, mirror_face,
 };
-use conspire::math::{TensorVec, tensor_rank_1};
+use conspire::math::{TensorRank1, TensorVec, tensor_rank_1};
 
 pub fn apply(
     cells_nodes: &[usize],
@@ -11,367 +11,316 @@ pub fn apply(
     element_node_connectivity: &mut HexConnectivity,
     nodal_coordinates: &mut Coordinates,
 ) {
-    tree.iter()
-        .filter_map(|cell| tree.cell_contains_leaves(cell))
-        .for_each(|(cell_subcells, _)| {
-            template(
-                0,
-                1,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                0,
-                2,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                0,
-                4,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                1,
-                3,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                1,
-                5,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                2,
-                3,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                2,
-                6,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                3,
-                7,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                4,
-                5,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                4,
-                6,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                5,
-                7,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            );
-            template(
-                6,
-                7,
-                cells_nodes,
-                cell_subcells,
-                nodes_map,
-                node_index,
-                tree,
-                element_node_connectivity,
-                nodal_coordinates,
-            )
-        })
+    tree.iter().for_each(|cell| {
+        template(
+            0,
+            1,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            0,
+            4,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            1,
+            2,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            1,
+            4,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            2,
+            3,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            2,
+            5,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            3,
+            0,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            4,
+            2,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            4,
+            3,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            5,
+            0,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            5,
+            1,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+        template(
+            3,
+            5,
+            cell,
+            cells_nodes,
+            nodes_map,
+            node_index,
+            tree,
+            element_node_connectivity,
+            nodal_coordinates,
+        );
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
 fn template(
-    subcell_a: usize,
-    subcell_b: usize,
+    face_m: usize,
+    face_n: usize,
+    cell: &Cell,
     cells_nodes: &[usize],
-    cell_subcells: &[usize; NUM_OCTANTS],
     nodes_map: &mut NodeMap,
     node_index: &mut usize,
     tree: &Octree,
     element_node_connectivity: &mut HexConnectivity,
     nodal_coordinates: &mut Coordinates,
 ) {
-    let (face_m, face_n, subcell_c, subcell_d, subcell_e, subcell_f, flip, direction) =
-        match (subcell_a, subcell_b) {
-            (0, 1) => (0, 4, 2, 4, 3, 5, false, tensor_rank_1([0.0, 1.0, 0.0])),
-            (0, 2) => (3, 4, 1, 4, 3, 6, true, tensor_rank_1([1.0, 0.0, 0.0])),
-            (0, 4) => (3, 0, 1, 2, 5, 6, false, tensor_rank_1([1.0, 0.0, 0.0])),
-            (1, 3) => (1, 4, 0, 5, 2, 7, false, tensor_rank_1([-1.0, 0.0, 0.0])),
-            (1, 5) => (0, 1, 3, 0, 7, 4, false, tensor_rank_1([0.0, 1.0, 0.0])),
-            (2, 3) => (2, 4, 0, 6, 1, 7, true, tensor_rank_1([0.0, -1.0, 0.0])),
-            (2, 6) => (2, 3, 0, 3, 4, 7, false, tensor_rank_1([0.0, -1.0, 0.0])),
-            (3, 7) => (1, 2, 2, 1, 6, 5, false, tensor_rank_1([-1.0, 0.0, 0.0])),
-            (4, 5) => (5, 0, 0, 6, 1, 7, false, tensor_rank_1([0.0, 0.0, -1.0])),
-            (4, 6) => (5, 3, 0, 5, 2, 7, true, tensor_rank_1([0.0, 0.0, -1.0])),
-            (5, 7) => (5, 1, 1, 4, 3, 6, false, tensor_rank_1([0.0, 0.0, -1.0])),
-            (6, 7) => (5, 2, 2, 4, 3, 5, true, tensor_rank_1([0.0, 0.0, -1.0])),
+    let (
+        subcell_m_a,
+        subcell_m_b,
+        subcell_m_c,
+        subcell_m_d,
+        subcell_face_m_a,
+        subcell_face_m_b,
+        subcell_face_n_a,
+        subcell_face_n_b,
+        subcell_diag_mn_a,
+        subcell_diag_mn_b,
+    ) = match (face_m, face_n) {
+        (0, 1) => (7, 13, 5, 15, 3, 7, 0, 4, 2, 6),
+        (0, 4) => (1, 4, 0, 5, 2, 3, 4, 5, 6, 7),
+        (1, 2) => (7, 13, 5, 15, 2, 6, 1, 5, 0, 4),
+        (1, 4) => (1, 4, 0, 5, 0, 2, 5, 7, 4, 6),
+        (2, 3) => (2, 8, 0, 10, 0, 4, 3, 7, 1, 5),
+        (2, 5) => (11, 14, 10, 15, 4, 5, 2, 3, 0, 1),
+        (3, 0) => (2, 8, 0, 10, 1, 5, 2, 6, 3, 7),
+        (3, 5) => (11, 14, 10, 15, 5, 7, 0, 2, 1, 3),
+        (4, 2) => (11, 14, 10, 15, 6, 7, 0, 1, 4, 5),
+        (4, 3) => (2, 8, 0, 10, 4, 6, 1, 3, 5, 7),
+        (5, 0) => (1, 4, 0, 5, 0, 1, 6, 7, 2, 3),
+        (5, 1) => (7, 13, 5, 15, 1, 3, 4, 6, 0, 2),
+        _ => panic!(),
+    };
+    let directions: [TensorRank1<3, 1>; 2] = [face_m, face_n]
+        .iter()
+        .map(|face| match face {
+            0 => tensor_rank_1([0.0, -1.0, 0.0]),
+            1 => tensor_rank_1([1.0, 0.0, 0.0]),
+            2 => tensor_rank_1([0.0, 1.0, 0.0]),
+            3 => tensor_rank_1([-1.0, 0.0, 0.0]),
+            4 => tensor_rank_1([0.0, 0.0, -1.0]),
+            5 => tensor_rank_1([0.0, 0.0, 1.0]),
             _ => panic!(),
-        };
-    let subcell_a_faces = tree[cell_subcells[subcell_a]].get_faces();
-    if let Some(subcell_a_face_m) = subcell_a_faces[face_m] {
-        if let Some(subcell_a_face_n) = subcell_a_faces[face_n] {
-            if let Some((subcell_a_face_m_subcells, _)) =
-                tree.cell_contains_leaves(&tree[subcell_a_face_m])
-            {
-                if let Some((subcell_a_face_n_subcells, _)) =
-                    tree.cell_contains_leaves(&tree[subcell_a_face_n])
-                {
-                    if let Some(diagonal_a) =
-                        tree[subcell_a_face_m_subcells[subcell_c]].get_faces()[face_n]
+        })
+        .collect::<Vec<TensorRank1<3, 1>>>()
+        .try_into()
+        .unwrap();
+    if let Some(cell_face_m) = cell.get_faces()[face_m] {
+        if let Some(cell_face_n) = cell.get_faces()[face_n] {
+            if let Some(cell_diag_mn) = tree[cell_face_m].get_faces()[face_n] {
+                if let Some((subcells_face_m, _)) = tree.cell_contains_leaves(&tree[cell_face_m]) {
+                    if let Some((subcells_face_n, _)) =
+                        tree.cell_contains_leaves(&tree[cell_face_n])
                     {
-                        if let Some(subdiagonal_a) =
-                            tree[subcell_a_face_m_subcells[subcell_e]].get_faces()[face_n]
+                        if let Some((subcells_diag_mn, _)) =
+                            tree.cell_contains_leaves(&tree[cell_diag_mn])
                         {
-                            let subcell_b_faces = tree[cell_subcells[subcell_b]].get_faces();
-                            if let Some(subcell_b_face_m) = subcell_b_faces[face_m] {
-                                if let Some(subcell_b_face_n) = subcell_b_faces[face_n] {
-                                    if let Some((subcell_b_face_m_subcells, _)) =
-                                        tree.cell_contains_leaves(&tree[subcell_b_face_m])
-                                    {
-                                        if let Some((subcell_b_face_n_subcells, _)) =
-                                            tree.cell_contains_leaves(&tree[subcell_b_face_n])
-                                        {
-                                            if let Some(diagonal_b) = tree
-                                                [subcell_b_face_m_subcells[subcell_e]]
-                                                .get_faces()[face_n]
-                                            {
-                                                if let Some(subdiagonal_b) = tree
-                                                    [subcell_b_face_m_subcells[subcell_c]]
-                                                    .get_faces()[face_n]
-                                                {
-                                                    if cells_nodes[diagonal_a] == 0 {
-                                                        println!(
-                                                            "Cell diagonal_a={} is node 0, leaf is {}",
-                                                            diagonal_a,
-                                                            tree[diagonal_a].is_leaf()
-                                                        );
-                                                    } else {
-                                                        assert!(tree[diagonal_a].is_leaf())
-                                                    }
-                                                    if cells_nodes[diagonal_b] == 0 {
-                                                        println!(
-                                                            "Cell diagonal_b={} is node 0, leaf is {}",
-                                                            diagonal_b,
-                                                            tree[diagonal_b].is_leaf()
-                                                        );
-                                                    } else {
-                                                        assert!(tree[diagonal_b].is_leaf())
-                                                    }
-                                                    if cells_nodes[subdiagonal_a] == 0 {
-                                                        println!(
-                                                            "Cell subdiagonal_a={} is node 0, leaf is {}",
-                                                            subdiagonal_a,
-                                                            tree[subdiagonal_a].is_leaf()
-                                                        );
-                                                    } else {
-                                                        assert!(tree[subdiagonal_a].is_leaf())
-                                                    }
-                                                    if cells_nodes[subdiagonal_b] == 0 {
-                                                        println!(
-                                                            "Cell subdiagonal_b={} is node 0, leaf is {}",
-                                                            subdiagonal_b,
-                                                            tree[subdiagonal_b].is_leaf()
-                                                        );
-                                                    } else {
-                                                        assert!(tree[subdiagonal_b].is_leaf())
-                                                    }
-                                                    let lngth = *tree
-                                                        [subcell_a_face_m_subcells[subcell_e]]
-                                                        .get_lngth()
-                                                        as f64;
-                                                    nodal_coordinates.push(
-                                                        &nodal_coordinates[cells_nodes
-                                                            [subcell_a_face_m_subcells[subcell_e]]
-                                                            - NODE_NUMBERING_OFFSET]
-                                                            + &direction * lngth,
-                                                    );
-                                                    nodal_coordinates.push(
-                                                        &nodal_coordinates[cells_nodes
-                                                            [subcell_b_face_m_subcells[subcell_c]]
-                                                            - NODE_NUMBERING_OFFSET]
-                                                            + direction * lngth,
-                                                    );
-                                                    (0..2).for_each(|k| {
-                                                        assert!(nodes_map.insert(
-                                                            (
-                                                                (2.0 * nodal_coordinates[*node_index
-                                                                    + k
-                                                                    - NODE_NUMBERING_OFFSET][0])
-                                                                    as usize,
-                                                                (2.0 * nodal_coordinates[*node_index
-                                                                    + k
-                                                                    - NODE_NUMBERING_OFFSET][1])
-                                                                    as usize,
-                                                                (2.0 * nodal_coordinates[*node_index
-                                                                    + k
-                                                                    - NODE_NUMBERING_OFFSET][2])
-                                                                    as usize,
-                                                            ),
-                                                            *node_index + k,
-                                                        ).is_none(), "duplicate entry")
-                                                    });
-                                                    if flip {
-                                                        element_node_connectivity.push([
-                                                            *node_index,
-                                                            cells_nodes[subcell_a_face_m_subcells
-                                                                [subcell_e]],
-                                                            cells_nodes[subdiagonal_a],
-                                                            cells_nodes[subcell_a_face_n_subcells
-                                                                [subcell_f]],
-                                                            cells_nodes[cell_subcells[subcell_a]],
-                                                            cells_nodes[subcell_a_face_m_subcells
-                                                                [subcell_c]],
-                                                            cells_nodes[diagonal_a],
-                                                            cells_nodes[subcell_a_face_n_subcells
-                                                                [subcell_d]],
-                                                        ]);
-                                                        element_node_connectivity.push([
-                                                            *node_index + 1,
-                                                            cells_nodes[subcell_b_face_m_subcells
-                                                                [subcell_c]],
-                                                            cells_nodes[subdiagonal_b],
-                                                            cells_nodes[subcell_b_face_n_subcells
-                                                                [subcell_d]],
-                                                            *node_index,
-                                                            cells_nodes[subcell_a_face_m_subcells
-                                                                [subcell_e]],
-                                                            cells_nodes[subdiagonal_a],
-                                                            cells_nodes[subcell_a_face_n_subcells
-                                                                [subcell_f]],
-                                                        ]);
-                                                        element_node_connectivity.push([
-                                                            cells_nodes[cell_subcells[subcell_b]],
-                                                            cells_nodes[subcell_b_face_m_subcells
-                                                                [subcell_e]],
-                                                            cells_nodes[diagonal_b],
-                                                            cells_nodes[subcell_b_face_n_subcells
-                                                                [subcell_f]],
-                                                            *node_index + 1,
-                                                            cells_nodes[subcell_b_face_m_subcells
-                                                                [subcell_c]],
-                                                            cells_nodes[subdiagonal_b],
-                                                            cells_nodes[subcell_b_face_n_subcells
-                                                                [subcell_d]],
-                                                        ]);
-                                                    } else {
-                                                        element_node_connectivity.push([
-                                                            cells_nodes[cell_subcells[subcell_a]],
-                                                            cells_nodes[subcell_a_face_m_subcells
-                                                                [subcell_c]],
-                                                            cells_nodes[diagonal_a],
-                                                            cells_nodes[subcell_a_face_n_subcells
-                                                                [subcell_d]],
-                                                            *node_index,
-                                                            cells_nodes[subcell_a_face_m_subcells
-                                                                [subcell_e]],
-                                                            cells_nodes[subdiagonal_a],
-                                                            cells_nodes[subcell_a_face_n_subcells
-                                                                [subcell_f]],
-                                                        ]);
-                                                        element_node_connectivity.push([
-                                                            *node_index,
-                                                            cells_nodes[subcell_a_face_m_subcells
-                                                                [subcell_e]],
-                                                            cells_nodes[subdiagonal_a],
-                                                            cells_nodes[subcell_a_face_n_subcells
-                                                                [subcell_f]],
-                                                            *node_index + 1,
-                                                            cells_nodes[subcell_b_face_m_subcells
-                                                                [subcell_c]],
-                                                            cells_nodes[subdiagonal_b],
-                                                            cells_nodes[subcell_b_face_n_subcells
-                                                                [subcell_d]],
-                                                        ]);
-                                                        element_node_connectivity.push([
-                                                            *node_index + 1,
-                                                            cells_nodes[subcell_b_face_m_subcells
-                                                                [subcell_c]],
-                                                            cells_nodes[subdiagonal_b],
-                                                            cells_nodes[subcell_b_face_n_subcells
-                                                                [subcell_d]],
-                                                            cells_nodes[cell_subcells[subcell_b]],
-                                                            cells_nodes[subcell_b_face_m_subcells
-                                                                [subcell_e]],
-                                                            cells_nodes[diagonal_b],
-                                                            cells_nodes[subcell_b_face_n_subcells
-                                                                [subcell_f]],
-                                                        ]);
-                                                    }
-                                                    *node_index += 2;
-                                                }
-                                            }
-                                        }
-                                    }
+                            if let Some(subcells_m) =
+                                tree.cell_subcells_contain_leaves(cell, mirror_face(face_m))
+                            {
+                                if tree
+                                    .cell_subcells_contain_leaves(cell, mirror_face(face_n))
+                                    .is_some()
+                                {
+                                    let lngth = *tree[subcells_m[subcell_m_a]].get_lngth() as f64;
+                                    nodal_coordinates.push(
+                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_a]]
+                                            - NODE_NUMBERING_OFFSET]
+                                            + &directions[0] * lngth,
+                                    );
+                                    nodal_coordinates.push(
+                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_a]]
+                                            - NODE_NUMBERING_OFFSET]
+                                            + &directions[0] * lngth
+                                            + &directions[1] * lngth,
+                                    );
+                                    nodal_coordinates.push(
+                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_a]]
+                                            - NODE_NUMBERING_OFFSET]
+                                            + &directions[1] * lngth,
+                                    );
+                                    nodal_coordinates.push(
+                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_b]]
+                                            - NODE_NUMBERING_OFFSET]
+                                            + &directions[0] * lngth,
+                                    );
+                                    nodal_coordinates.push(
+                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_b]]
+                                            - NODE_NUMBERING_OFFSET]
+                                            + &directions[0] * lngth
+                                            + &directions[1] * lngth,
+                                    );
+                                    nodal_coordinates.push(
+                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_b]]
+                                            - NODE_NUMBERING_OFFSET]
+                                            + &directions[1] * lngth,
+                                    );
+                                    (0..6).for_each(|k| {
+                                        assert!(
+                                            nodes_map
+                                                .insert(
+                                                    (
+                                                        (2.0 * nodal_coordinates[*node_index + k
+                                                            - NODE_NUMBERING_OFFSET][0])
+                                                            as usize,
+                                                        (2.0 * nodal_coordinates[*node_index + k
+                                                            - NODE_NUMBERING_OFFSET][1])
+                                                            as usize,
+                                                        (2.0 * nodal_coordinates[*node_index + k
+                                                            - NODE_NUMBERING_OFFSET][2])
+                                                            as usize,
+                                                    ),
+                                                    *node_index + k,
+                                                )
+                                                .is_none(),
+                                            "duplicate entry"
+                                        )
+                                    });
+                                    element_node_connectivity.push([
+                                        cells_nodes[subcells_m[subcell_m_a]],
+                                        *node_index,
+                                        *node_index + 1,
+                                        *node_index + 2,
+                                        cells_nodes[subcells_m[subcell_m_b]],
+                                        *node_index + 3,
+                                        *node_index + 4,
+                                        *node_index + 5,
+                                    ]);
+                                    element_node_connectivity.push([
+                                        *node_index,
+                                        cells_nodes[subcells_face_m[subcell_face_m_a]],
+                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_a]],
+                                        *node_index + 1,
+                                        *node_index + 3,
+                                        cells_nodes[subcells_face_m[subcell_face_m_b]],
+                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_b]],
+                                        *node_index + 4,
+                                    ]);
+                                    element_node_connectivity.push([
+                                        *node_index + 1,
+                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_a]],
+                                        cells_nodes[subcells_face_n[subcell_face_n_a]],
+                                        *node_index + 2,
+                                        *node_index + 4,
+                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_b]],
+                                        cells_nodes[subcells_face_n[subcell_face_n_b]],
+                                        *node_index + 5,
+                                    ]);
+                                    element_node_connectivity.push([
+                                        cells_nodes[subcells_m[subcell_m_a]],
+                                        *node_index + 2,
+                                        *node_index + 1,
+                                        *node_index,
+                                        cells_nodes[subcells_m[subcell_m_c]],
+                                        cells_nodes[subcells_face_n[subcell_face_n_a]],
+                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_a]],
+                                        cells_nodes[subcells_face_m[subcell_face_m_a]],
+                                    ]);
+                                    element_node_connectivity.push([
+                                        cells_nodes[subcells_m[subcell_m_b]],
+                                        *node_index + 3,
+                                        *node_index + 4,
+                                        *node_index + 5,
+                                        cells_nodes[subcells_m[subcell_m_d]],
+                                        cells_nodes[subcells_face_m[subcell_face_m_b]],
+                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_b]],
+                                        cells_nodes[subcells_face_n[subcell_face_n_b]],
+                                    ]);
+                                    *node_index += 6;
                                 }
                             }
                         }

--- a/src/tree/hex/edge_template_2/mod.rs
+++ b/src/tree/hex/edge_template_2/mod.rs
@@ -4,11 +4,11 @@ use super::super::{
 
 pub fn apply(
     cells_nodes: &[usize],
-    nodes_map: &mut NodeMap,
+    nodes_map: &NodeMap,
     tree: &Octree,
-    element_node_connectivity: &mut HexConnectivity,
     nodal_coordinates: &Coordinates,
-) {
+) -> HexConnectivity {
+    let mut element_node_connectivity = vec![];
     tree.iter()
         .filter_map(|cell| tree.cell_contains_leaves(cell))
         .for_each(|(cell_subcells, cell_faces)| {
@@ -166,7 +166,8 @@ pub fn apply(
                         }
                     }
                 })
-        })
+        });
+    element_node_connectivity
 }
 
 fn template_inner(face_index: usize) -> [[usize; 13]; 2] {

--- a/src/tree/hex/edge_template_2/mod.rs
+++ b/src/tree/hex/edge_template_2/mod.rs
@@ -1,332 +1,200 @@
 use super::super::{
-    Cell, Coordinates, HexConnectivity, NODE_NUMBERING_OFFSET, NodeMap, Octree, mirror_face,
+    Coordinates, HexConnectivity, NODE_NUMBERING_OFFSET, NodeMap, Octree, face_direction,
 };
-use conspire::math::{TensorRank1, TensorVec, tensor_rank_1};
 
 pub fn apply(
     cells_nodes: &[usize],
     nodes_map: &mut NodeMap,
-    node_index: &mut usize,
     tree: &Octree,
     element_node_connectivity: &mut HexConnectivity,
-    nodal_coordinates: &mut Coordinates,
+    nodal_coordinates: &Coordinates,
 ) {
-    tree.iter().for_each(|cell| {
-        template(
-            0,
-            1,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            0,
-            4,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            1,
-            2,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            1,
-            4,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            2,
-            3,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            2,
-            5,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            3,
-            0,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            4,
-            2,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            4,
-            3,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            5,
-            0,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            5,
-            1,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-        template(
-            3,
-            5,
-            cell,
-            cells_nodes,
-            nodes_map,
-            node_index,
-            tree,
-            element_node_connectivity,
-            nodal_coordinates,
-        );
-    })
-}
-
-#[allow(clippy::too_many_arguments)]
-fn template(
-    face_m: usize,
-    face_n: usize,
-    cell: &Cell,
-    cells_nodes: &[usize],
-    nodes_map: &mut NodeMap,
-    node_index: &mut usize,
-    tree: &Octree,
-    element_node_connectivity: &mut HexConnectivity,
-    nodal_coordinates: &mut Coordinates,
-) {
-    let (
-        subcell_m_a,
-        subcell_m_b,
-        subcell_m_c,
-        subcell_m_d,
-        subcell_face_m_a,
-        subcell_face_m_b,
-        subcell_face_n_a,
-        subcell_face_n_b,
-        subcell_diag_mn_a,
-        subcell_diag_mn_b,
-    ) = match (face_m, face_n) {
-        (0, 1) => (7, 13, 5, 15, 3, 7, 0, 4, 2, 6),
-        (0, 4) => (1, 4, 0, 5, 2, 3, 4, 5, 6, 7),
-        (1, 2) => (7, 13, 5, 15, 2, 6, 1, 5, 0, 4),
-        (1, 4) => (1, 4, 0, 5, 0, 2, 5, 7, 4, 6),
-        (2, 3) => (2, 8, 0, 10, 0, 4, 3, 7, 1, 5),
-        (2, 5) => (11, 14, 10, 15, 4, 5, 2, 3, 0, 1),
-        (3, 0) => (2, 8, 0, 10, 1, 5, 2, 6, 3, 7),
-        (3, 5) => (11, 14, 10, 15, 5, 7, 0, 2, 1, 3),
-        (4, 2) => (11, 14, 10, 15, 6, 7, 0, 1, 4, 5),
-        (4, 3) => (2, 8, 0, 10, 4, 6, 1, 3, 5, 7),
-        (5, 0) => (1, 4, 0, 5, 0, 1, 6, 7, 2, 3),
-        (5, 1) => (7, 13, 5, 15, 1, 3, 4, 6, 0, 2),
-        _ => panic!(),
-    };
-    let directions: [TensorRank1<3, 1>; 2] = [face_m, face_n]
-        .iter()
-        .map(|face| match face {
-            0 => tensor_rank_1([0.0, -1.0, 0.0]),
-            1 => tensor_rank_1([1.0, 0.0, 0.0]),
-            2 => tensor_rank_1([0.0, 1.0, 0.0]),
-            3 => tensor_rank_1([-1.0, 0.0, 0.0]),
-            4 => tensor_rank_1([0.0, 0.0, -1.0]),
-            5 => tensor_rank_1([0.0, 0.0, 1.0]),
-            _ => panic!(),
-        })
-        .collect::<Vec<TensorRank1<3, 1>>>()
-        .try_into()
-        .unwrap();
-    if let Some(cell_face_m) = cell.get_faces()[face_m] {
-        if let Some(cell_face_n) = cell.get_faces()[face_n] {
-            if let Some(cell_diag_mn) = tree[cell_face_m].get_faces()[face_n] {
-                if let Some((subcells_face_m, _)) = tree.cell_contains_leaves(&tree[cell_face_m]) {
-                    if let Some((subcells_face_n, _)) =
-                        tree.cell_contains_leaves(&tree[cell_face_n])
-                    {
-                        if let Some((subcells_diag_mn, _)) =
-                            tree.cell_contains_leaves(&tree[cell_diag_mn])
+    tree.iter()
+        .filter_map(|cell| tree.cell_contains_leaves(cell))
+        .for_each(|(cell_subcells, cell_faces)| {
+            cell_faces
+                .iter()
+                .enumerate()
+                .for_each(|(face_index, face_cell)| {
+                    if let Some(face_cell_index) = face_cell {
+                        if let Some(face_subsubcells) =
+                            tree.cell_subcells_contain_leaves(&tree[*face_cell_index], face_index)
                         {
-                            if let Some(subcells_m) =
-                                tree.cell_subcells_contain_leaves(cell, mirror_face(face_m))
-                            {
-                                if tree
-                                    .cell_subcells_contain_leaves(cell, mirror_face(face_n))
-                                    .is_some()
-                                {
-                                    let lngth = *tree[subcells_m[subcell_m_a]].get_lngth() as f64;
-                                    nodal_coordinates.push(
-                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_a]]
-                                            - NODE_NUMBERING_OFFSET]
-                                            + &directions[0] * lngth,
-                                    );
-                                    nodal_coordinates.push(
-                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_a]]
-                                            - NODE_NUMBERING_OFFSET]
-                                            + &directions[0] * lngth
-                                            + &directions[1] * lngth,
-                                    );
-                                    nodal_coordinates.push(
-                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_a]]
-                                            - NODE_NUMBERING_OFFSET]
-                                            + &directions[1] * lngth,
-                                    );
-                                    nodal_coordinates.push(
-                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_b]]
-                                            - NODE_NUMBERING_OFFSET]
-                                            + &directions[0] * lngth,
-                                    );
-                                    nodal_coordinates.push(
-                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_b]]
-                                            - NODE_NUMBERING_OFFSET]
-                                            + &directions[0] * lngth
-                                            + &directions[1] * lngth,
-                                    );
-                                    nodal_coordinates.push(
-                                        &nodal_coordinates[cells_nodes[subcells_m[subcell_m_b]]
-                                            - NODE_NUMBERING_OFFSET]
-                                            + &directions[1] * lngth,
-                                    );
-                                    (0..6).for_each(|k| {
-                                        assert!(
-                                            nodes_map
-                                                .insert(
-                                                    (
-                                                        (2.0 * nodal_coordinates[*node_index + k
-                                                            - NODE_NUMBERING_OFFSET][0])
-                                                            as usize,
-                                                        (2.0 * nodal_coordinates[*node_index + k
-                                                            - NODE_NUMBERING_OFFSET][1])
-                                                            as usize,
-                                                        (2.0 * nodal_coordinates[*node_index + k
-                                                            - NODE_NUMBERING_OFFSET][2])
-                                                            as usize,
-                                                    ),
-                                                    *node_index + k,
-                                                )
-                                                .is_none(),
-                                            "duplicate entry"
-                                        )
-                                    });
-                                    element_node_connectivity.push([
-                                        cells_nodes[subcells_m[subcell_m_a]],
-                                        *node_index,
-                                        *node_index + 1,
-                                        *node_index + 2,
-                                        cells_nodes[subcells_m[subcell_m_b]],
-                                        *node_index + 3,
-                                        *node_index + 4,
-                                        *node_index + 5,
-                                    ]);
-                                    element_node_connectivity.push([
-                                        *node_index,
-                                        cells_nodes[subcells_face_m[subcell_face_m_a]],
-                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_a]],
-                                        *node_index + 1,
-                                        *node_index + 3,
-                                        cells_nodes[subcells_face_m[subcell_face_m_b]],
-                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_b]],
-                                        *node_index + 4,
-                                    ]);
-                                    element_node_connectivity.push([
-                                        *node_index + 1,
-                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_a]],
-                                        cells_nodes[subcells_face_n[subcell_face_n_a]],
-                                        *node_index + 2,
-                                        *node_index + 4,
-                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_b]],
-                                        cells_nodes[subcells_face_n[subcell_face_n_b]],
-                                        *node_index + 5,
-                                    ]);
-                                    element_node_connectivity.push([
-                                        cells_nodes[subcells_m[subcell_m_a]],
-                                        *node_index + 2,
-                                        *node_index + 1,
-                                        *node_index,
-                                        cells_nodes[subcells_m[subcell_m_c]],
-                                        cells_nodes[subcells_face_n[subcell_face_n_a]],
-                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_a]],
-                                        cells_nodes[subcells_face_m[subcell_face_m_a]],
-                                    ]);
-                                    element_node_connectivity.push([
-                                        cells_nodes[subcells_m[subcell_m_b]],
-                                        *node_index + 3,
-                                        *node_index + 4,
-                                        *node_index + 5,
-                                        cells_nodes[subcells_m[subcell_m_d]],
-                                        cells_nodes[subcells_face_m[subcell_face_m_b]],
-                                        cells_nodes[subcells_diag_mn[subcell_diag_mn_b]],
-                                        cells_nodes[subcells_face_n[subcell_face_n_b]],
-                                    ]);
-                                    *node_index += 6;
-                                }
-                            }
+                            template_inner(face_index).into_iter().for_each(
+                                |[
+                                    adjacent_face,
+                                    cell_subcell_a,
+                                    cell_subcell_b,
+                                    adjacent_cell_subcell_a,
+                                    adjacent_cell_subcell_b,
+                                    face_subsubcell_a,
+                                    face_subsubcell_b,
+                                    face_subsubcell_c,
+                                    face_subsubcell_d,
+                                    adjacent_face_subsubcell_a,
+                                    adjacent_face_subsubcell_b,
+                                    adjacent_face_subsubcell_c,
+                                    adjacent_face_subsubcell_d,
+                                ]| {
+                                    if let Some(adjacent_cell) = cell_faces[adjacent_face] {
+                                        if let Some((adjacent_cell_subcells, adjacent_cell_faces)) =
+                                            tree.cell_contains_leaves(&tree[adjacent_cell])
+                                        {
+                                            if let Some(adjacent_cell_face_cell) =
+                                                adjacent_cell_faces[face_index]
+                                            {
+                                                if let Some(adjacent_face_subsubcells) = tree
+                                                    .cell_subcells_contain_leaves(
+                                                        &tree[adjacent_cell_face_cell],
+                                                        face_index,
+                                                    )
+                                                {
+                                                    let lngth = *tree
+                                                        [face_subsubcells[face_subsubcell_a]]
+                                                        .get_lngth()
+                                                        as f64;
+                                                    let coordinates_1 = &nodal_coordinates
+                                                        [cells_nodes
+                                                            [face_subsubcells[face_subsubcell_a]]
+                                                            - NODE_NUMBERING_OFFSET]
+                                                        - face_direction(face_index) * lngth;
+                                                    let node_1 = *nodes_map
+                                                        .get(&(
+                                                            (2.0 * coordinates_1[0]) as usize,
+                                                            (2.0 * coordinates_1[1]) as usize,
+                                                            (2.0 * coordinates_1[2]) as usize,
+                                                        ))
+                                                        .expect("nonexistent entry");
+                                                    let coordinates_2 = &nodal_coordinates
+                                                        [cells_nodes
+                                                            [face_subsubcells[face_subsubcell_b]]
+                                                            - NODE_NUMBERING_OFFSET]
+                                                        - face_direction(face_index) * lngth;
+                                                    let node_2 = *nodes_map
+                                                        .get(&(
+                                                            (2.0 * coordinates_2[0]) as usize,
+                                                            (2.0 * coordinates_2[1]) as usize,
+                                                            (2.0 * coordinates_2[2]) as usize,
+                                                        ))
+                                                        .expect("nonexistent entry");
+                                                    let coordinates_3 = &nodal_coordinates
+                                                        [cells_nodes[adjacent_face_subsubcells
+                                                            [adjacent_face_subsubcell_a]]
+                                                            - NODE_NUMBERING_OFFSET]
+                                                        - face_direction(face_index) * lngth;
+                                                    let node_3 = *nodes_map
+                                                        .get(&(
+                                                            (2.0 * coordinates_3[0]) as usize,
+                                                            (2.0 * coordinates_3[1]) as usize,
+                                                            (2.0 * coordinates_3[2]) as usize,
+                                                        ))
+                                                        .expect("nonexistent entry");
+                                                    let coordinates_4 = &nodal_coordinates
+                                                        [cells_nodes[adjacent_face_subsubcells
+                                                            [adjacent_face_subsubcell_b]]
+                                                            - NODE_NUMBERING_OFFSET]
+                                                        - face_direction(face_index) * lngth;
+                                                    let node_4 = *nodes_map
+                                                        .get(&(
+                                                            (2.0 * coordinates_4[0]) as usize,
+                                                            (2.0 * coordinates_4[1]) as usize,
+                                                            (2.0 * coordinates_4[2]) as usize,
+                                                        ))
+                                                        .expect("nonexistent entry");
+                                                    element_node_connectivity.push([
+                                                        cells_nodes[cell_subcells[cell_subcell_a]],
+                                                        cells_nodes[cell_subcells[cell_subcell_b]],
+                                                        node_1,
+                                                        node_2,
+                                                        cells_nodes[adjacent_cell_subcells
+                                                            [adjacent_cell_subcell_a]],
+                                                        cells_nodes[adjacent_cell_subcells
+                                                            [adjacent_cell_subcell_b]],
+                                                        node_3,
+                                                        node_4,
+                                                    ]);
+                                                    element_node_connectivity.push([
+                                                        cells_nodes
+                                                            [face_subsubcells[face_subsubcell_a]],
+                                                        cells_nodes
+                                                            [face_subsubcells[face_subsubcell_b]],
+                                                        node_2,
+                                                        node_1,
+                                                        cells_nodes[adjacent_face_subsubcells
+                                                            [adjacent_face_subsubcell_a]],
+                                                        cells_nodes[adjacent_face_subsubcells
+                                                            [adjacent_face_subsubcell_b]],
+                                                        node_4,
+                                                        node_3,
+                                                    ]);
+                                                    element_node_connectivity.push([
+                                                        cells_nodes
+                                                            [face_subsubcells[face_subsubcell_b]],
+                                                        node_2,
+                                                        node_4,
+                                                        cells_nodes[adjacent_face_subsubcells
+                                                            [adjacent_face_subsubcell_b]],
+                                                        cells_nodes
+                                                            [face_subsubcells[face_subsubcell_d]],
+                                                        cells_nodes[cell_subcells[cell_subcell_a]],
+                                                        cells_nodes[adjacent_cell_subcells
+                                                            [adjacent_cell_subcell_a]],
+                                                        cells_nodes[adjacent_face_subsubcells
+                                                            [adjacent_face_subsubcell_d]],
+                                                    ]);
+                                                    element_node_connectivity.push([
+                                                        cells_nodes
+                                                            [face_subsubcells[face_subsubcell_a]],
+                                                        cells_nodes[adjacent_face_subsubcells
+                                                            [adjacent_face_subsubcell_a]],
+                                                        node_3,
+                                                        node_1,
+                                                        cells_nodes
+                                                            [face_subsubcells[face_subsubcell_c]],
+                                                        cells_nodes[adjacent_face_subsubcells
+                                                            [adjacent_face_subsubcell_c]],
+                                                        cells_nodes[adjacent_cell_subcells
+                                                            [adjacent_cell_subcell_b]],
+                                                        cells_nodes[cell_subcells[cell_subcell_b]],
+                                                    ]);
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                            )
                         }
                     }
-                }
-            }
-        }
+                })
+        })
+}
+
+fn template_inner(face_index: usize) -> [[usize; 13]; 2] {
+    match face_index {
+        0 => [
+            [1, 1, 5, 0, 4, 13, 7, 15, 5, 8, 2, 10, 0],
+            [4, 0, 1, 4, 5, 4, 1, 5, 0, 14, 11, 15, 10],
+        ],
+        1 => [
+            [0, 5, 1, 7, 3, 2, 8, 0, 10, 7, 13, 5, 15],
+            [4, 1, 3, 5, 7, 4, 1, 5, 0, 14, 11, 15, 10],
+        ],
+        2 => [
+            [1, 7, 3, 6, 2, 7, 13, 5, 15, 2, 8, 0, 10],
+            [5, 6, 7, 2, 3, 14, 11, 15, 10, 4, 1, 5, 0],
+        ],
+        3 => [
+            [2, 6, 2, 4, 0, 7, 13, 5, 15, 2, 8, 0, 10],
+            [5, 4, 6, 0, 2, 14, 11, 15, 10, 4, 1, 5, 0],
+        ],
+        4 => [
+            [1, 3, 1, 2, 0, 7, 13, 5, 15, 2, 8, 0, 10],
+            [2, 2, 3, 0, 1, 14, 11, 15, 10, 4, 1, 5, 0],
+        ],
+        5 => [
+            [0, 4, 5, 6, 7, 4, 1, 5, 0, 14, 11, 15, 10],
+            [3, 6, 4, 7, 5, 2, 8, 0, 10, 7, 13, 5, 15],
+        ],
+        _ => panic!(),
     }
 }

--- a/src/tree/hex/edge_template_4/mod.rs
+++ b/src/tree/hex/edge_template_4/mod.rs
@@ -5,11 +5,11 @@ use super::super::{
 
 pub fn apply(
     cells_nodes: &[usize],
-    nodes_map: &mut NodeMap,
+    nodes_map: &NodeMap,
     tree: &Octree,
-    element_node_connectivity: &mut HexConnectivity,
     nodal_coordinates: &Coordinates,
-) {
+) -> HexConnectivity {
+    let mut element_node_connectivity = vec![];
     tree.iter()
         .filter_map(|cell| tree.cell_contains_leaves(cell))
         .for_each(|(cell_subcells, _)| {
@@ -26,7 +26,7 @@ pub fn apply(
                 cell_subcells,
                 nodes_map,
                 tree,
-                element_node_connectivity,
+                &mut element_node_connectivity,
                 nodal_coordinates,
             );
             template(
@@ -42,7 +42,7 @@ pub fn apply(
                 cell_subcells,
                 nodes_map,
                 tree,
-                element_node_connectivity,
+                &mut element_node_connectivity,
                 nodal_coordinates,
             );
             template(
@@ -58,7 +58,7 @@ pub fn apply(
                 cell_subcells,
                 nodes_map,
                 tree,
-                element_node_connectivity,
+                &mut element_node_connectivity,
                 nodal_coordinates,
             );
             template(
@@ -74,7 +74,7 @@ pub fn apply(
                 cell_subcells,
                 nodes_map,
                 tree,
-                element_node_connectivity,
+                &mut element_node_connectivity,
                 nodal_coordinates,
             );
             template(
@@ -90,7 +90,7 @@ pub fn apply(
                 cell_subcells,
                 nodes_map,
                 tree,
-                element_node_connectivity,
+                &mut element_node_connectivity,
                 nodal_coordinates,
             );
             template(
@@ -106,10 +106,11 @@ pub fn apply(
                 cell_subcells,
                 nodes_map,
                 tree,
-                element_node_connectivity,
+                &mut element_node_connectivity,
                 nodal_coordinates,
             );
-        })
+        });
+    element_node_connectivity
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -124,7 +125,7 @@ fn template(
     subcell_face_n_q: usize,
     cells_nodes: &[usize],
     cell_subcells: &[usize; NUM_OCTANTS],
-    nodes_map: &mut NodeMap,
+    nodes_map: &NodeMap,
     tree: &Octree,
     element_node_connectivity: &mut HexConnectivity,
     nodal_coordinates: &Coordinates,

--- a/src/tree/hex/edge_template_4/mod.rs
+++ b/src/tree/hex/edge_template_4/mod.rs
@@ -18,6 +18,90 @@ pub fn apply(
                 6,
                 3,
                 5,
+                7,
+                5,
+                2,
+                0,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                5,
+                7,
+                5,
+                1,
+                3,
+                1,
+                6,
+                4,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                5,
+                4,
+                0,
+                5,
+                6,
+                7,
+                0,
+                1,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                7,
+                6,
+                5,
+                2,
+                2,
+                3,
+                4,
+                5,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                6,
+                2,
+                3,
+                2,
+                3,
+                7,
+                0,
+                4,
+                cells_nodes,
+                cell_subcells,
+                nodes_map,
+                tree,
+                element_node_connectivity,
+                nodal_coordinates,
+            );
+            template(
+                7,
+                3,
+                2,
+                1,
+                1,
+                5,
+                2,
+                6,
                 cells_nodes,
                 cell_subcells,
                 nodes_map,
@@ -34,6 +118,10 @@ fn template(
     subcell_b: usize,
     face_m: usize,
     face_n: usize,
+    subcell_face_m_p: usize,
+    subcell_face_m_q: usize,
+    subcell_face_n_p: usize,
+    subcell_face_n_q: usize,
     cells_nodes: &[usize],
     cell_subcells: &[usize; NUM_OCTANTS],
     nodes_map: &mut NodeMap,
@@ -63,11 +151,13 @@ fn template(
                                                 if let Some((subcell_b_face_n_subcells, _)) = tree
                                                     .cell_contains_leaves(&tree[subcell_b_face_n])
                                                 {
-                                                    let lngth = *tree[subcell_a_face_m_subcells[7]]
+                                                    let lngth = *tree[subcell_a_face_m_subcells
+                                                        [subcell_face_m_p]]
                                                         .get_lngth()
                                                         as f64;
                                                     let coordinates_1 = &nodal_coordinates
-                                                        [cells_nodes[subcell_a_face_m_subcells[7]]
+                                                        [cells_nodes[subcell_a_face_m_subcells
+                                                            [subcell_face_m_p]]
                                                             - NODE_NUMBERING_OFFSET]
                                                         - face_direction(face_m) * lngth;
                                                     let node_1 = *nodes_map
@@ -78,7 +168,8 @@ fn template(
                                                         ))
                                                         .expect("nonexistent entry");
                                                     let coordinates_2 = &nodal_coordinates
-                                                        [cells_nodes[subcell_b_face_m_subcells[5]]
+                                                        [cells_nodes[subcell_b_face_m_subcells
+                                                            [subcell_face_m_q]]
                                                             - NODE_NUMBERING_OFFSET]
                                                         - face_direction(face_m) * lngth;
                                                     let node_2 = *nodes_map
@@ -89,7 +180,8 @@ fn template(
                                                         ))
                                                         .expect("nonexistent entry");
                                                     let coordinates_3 = &nodal_coordinates
-                                                        [cells_nodes[subcell_a_face_m_subcells[7]]
+                                                        [cells_nodes[subcell_a_face_m_subcells
+                                                            [subcell_face_m_p]]
                                                             - NODE_NUMBERING_OFFSET]
                                                         + face_direction(face_n) * lngth;
                                                     let node_3 = *nodes_map
@@ -100,7 +192,8 @@ fn template(
                                                         ))
                                                         .expect("nonexistent entry");
                                                     let coordinates_4 = &nodal_coordinates
-                                                        [cells_nodes[subcell_b_face_m_subcells[5]]
+                                                        [cells_nodes[subcell_b_face_m_subcells
+                                                            [subcell_face_m_q]]
                                                             - NODE_NUMBERING_OFFSET]
                                                         + face_direction(face_n) * lngth;
                                                     let node_4 = *nodes_map
@@ -111,33 +204,45 @@ fn template(
                                                         ))
                                                         .expect("nonexistent entry");
                                                     element_node_connectivity.push([
-                                                        cells_nodes[subcell_a_face_m_subcells[7]],
+                                                        cells_nodes[subcell_a_face_m_subcells
+                                                            [subcell_face_m_p]],
                                                         node_1,
                                                         node_2,
-                                                        cells_nodes[subcell_b_face_m_subcells[5]],
+                                                        cells_nodes[subcell_b_face_m_subcells
+                                                            [subcell_face_m_q]],
                                                         node_3,
-                                                        cells_nodes[subcell_a_face_n_subcells[2]],
-                                                        cells_nodes[subcell_b_face_n_subcells[0]],
+                                                        cells_nodes[subcell_a_face_n_subcells
+                                                            [subcell_face_n_p]],
+                                                        cells_nodes[subcell_b_face_n_subcells
+                                                            [subcell_face_n_q]],
                                                         node_4,
                                                     ]);
                                                     element_node_connectivity.push([
-                                                        cells_nodes[subcell_b_face_m_subcells[5]],
+                                                        cells_nodes[subcell_b_face_m_subcells
+                                                            [subcell_face_m_q]],
                                                         node_2,
                                                         cells_nodes[cell_subcells[subcell_b]],
-                                                        cells_nodes[subcell_b_face_m_subcells[7]],
+                                                        cells_nodes[subcell_b_face_m_subcells
+                                                            [subcell_face_m_p]],
                                                         node_4,
-                                                        cells_nodes[subcell_b_face_n_subcells[0]],
-                                                        cells_nodes[subcell_b_face_n_subcells[2]],
+                                                        cells_nodes[subcell_b_face_n_subcells
+                                                            [subcell_face_n_q]],
+                                                        cells_nodes[subcell_b_face_n_subcells
+                                                            [subcell_face_n_p]],
                                                         cells_nodes[diagonal_b],
                                                     ]);
                                                     element_node_connectivity.push([
-                                                        cells_nodes[subcell_a_face_m_subcells[5]],
+                                                        cells_nodes[subcell_a_face_m_subcells
+                                                            [subcell_face_m_q]],
                                                         cells_nodes[cell_subcells[subcell_a]],
                                                         node_1,
-                                                        cells_nodes[subcell_a_face_m_subcells[7]],
+                                                        cells_nodes[subcell_a_face_m_subcells
+                                                            [subcell_face_m_p]],
                                                         cells_nodes[diagonal_a],
-                                                        cells_nodes[subcell_a_face_n_subcells[0]],
-                                                        cells_nodes[subcell_a_face_n_subcells[2]],
+                                                        cells_nodes[subcell_a_face_n_subcells
+                                                            [subcell_face_n_q]],
+                                                        cells_nodes[subcell_a_face_n_subcells
+                                                            [subcell_face_n_p]],
                                                         node_3,
                                                     ]);
                                                 }

--- a/src/tree/hex/mod.rs
+++ b/src/tree/hex/mod.rs
@@ -1,4 +1,4 @@
-use super::{Faces, HEX, HexConnectivity, Indices, Octree};
+use super::{Coordinates, Faces, HEX, HexConnectivity, Indices, NodeMap, Octree};
 
 pub mod edge_template_1;
 pub mod edge_template_2;
@@ -19,7 +19,13 @@ mod vertex_template_7; // (O, a, ab, b) => (o, a, ab, b)
 mod vertex_template_8; // (O, A, AB, b) => (o, a, ab, b)
 mod vertex_template_9; // (O, a, ab, b) => (o, a, AB, b)
 
-pub fn vertex_template(index: usize, cells_nodes: &[usize], tree: &Octree) -> HexConnectivity {
+pub fn apply_concurrently(
+    index: usize,
+    cells_nodes: &[usize],
+    nodes_map: &NodeMap,
+    tree: &Octree,
+    nodal_coordinates: &Coordinates,
+) -> HexConnectivity {
     match index {
         1 => apply_vertex_template(
             cells_nodes,
@@ -93,6 +99,8 @@ pub fn vertex_template(index: usize, cells_nodes: &[usize], tree: &Octree) -> He
             vertex_template_12::DATA,
             vertex_template_12::template,
         ),
+        13 => edge_template_2::apply(cells_nodes, nodes_map, tree, nodal_coordinates),
+        14 => edge_template_4::apply(cells_nodes, nodes_map, tree, nodal_coordinates),
         _ => panic!(),
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1954,7 +1954,7 @@ impl From<Octree> for HexahedralFiniteElements {
             &mut element_node_connectivity,
             &mut nodal_coordinates,
         );
-        hex::edge_template_2::apply(
+        hex::edge_template_3::apply(
             &cells_nodes,
             &mut nodes_map,
             &mut node_index,
@@ -1977,12 +1977,25 @@ impl From<Octree> for HexahedralFiniteElements {
         //
         // May be able to make one function that calls either vertex or edge templates in order to keep in same par_iter().
         //
-        hex::edge_template_3::apply(
+        hex::edge_template_2::apply(
             &cells_nodes,
             &mut nodes_map,
             &tree,
             &mut element_node_connectivity,
             &nodal_coordinates,
+        );
+        // hex::edge_template_4::apply(
+        //     &cells_nodes,
+        //     &mut nodes_map,
+        //     &tree,
+        //     &mut element_node_connectivity,
+        //     &nodal_coordinates,
+        // );
+        element_node_connectivity.append(
+            &mut (1..=12)
+                .into_par_iter()
+                .flat_map(|index| hex::vertex_template(index, &cells_nodes, &tree))
+                .collect(),
         );
         hex::edge_template_4::apply(
             &cells_nodes,
@@ -1990,12 +2003,6 @@ impl From<Octree> for HexahedralFiniteElements {
             &tree,
             &mut element_node_connectivity,
             &nodal_coordinates,
-        );
-        element_node_connectivity.append(
-            &mut (1..=12)
-                .into_par_iter()
-                .flat_map(|index| hex::vertex_template(index, &cells_nodes, &tree))
-                .collect(),
         );
         let fem = Self::from_data(
             vec![1; element_node_connectivity.len()],

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -1970,39 +1970,19 @@ impl From<Octree> for HexahedralFiniteElements {
             &mut element_node_connectivity,
             &mut nodal_coordinates,
         );
-        //
-        // Below templates do not create new nodes,
-        // which means they are independent and can be run concurrently,
-        // returning separate connectivities to combine afterwards.
-        //
-        // May be able to make one function that calls either vertex or edge templates in order to keep in same par_iter().
-        //
-        hex::edge_template_2::apply(
-            &cells_nodes,
-            &mut nodes_map,
-            &tree,
-            &mut element_node_connectivity,
-            &nodal_coordinates,
-        );
-        // hex::edge_template_4::apply(
-        //     &cells_nodes,
-        //     &mut nodes_map,
-        //     &tree,
-        //     &mut element_node_connectivity,
-        //     &nodal_coordinates,
-        // );
         element_node_connectivity.append(
-            &mut (1..=12)
+            &mut (1..=14)
                 .into_par_iter()
-                .flat_map(|index| hex::vertex_template(index, &cells_nodes, &tree))
+                .flat_map(|index| {
+                    hex::apply_concurrently(
+                        index,
+                        &cells_nodes,
+                        &nodes_map,
+                        &tree,
+                        &nodal_coordinates,
+                    )
+                })
                 .collect(),
-        );
-        hex::edge_template_4::apply(
-            &cells_nodes,
-            &mut nodes_map,
-            &tree,
-            &mut element_node_connectivity,
-            &nodal_coordinates,
         );
         let fem = Self::from_data(
             vec![1; element_node_connectivity.len()],


### PR DESCRIPTION
fourth edge transition, parallelized 2 out of 4 edge transitions among all vertex transitions, over 99.9% hexes accounted for, just a few (4?) more vertex transitions to implement (will also be parallel)

<pre><font color="#58C7E0">cargo</font> <font color="#58C7E2">run</font> <font color="#58C7E2">-qr</font> <font color="#58C7E2">--</font> <font color="#58C7E2">mesh</font> <font color="#58C7E2">hex</font> <font color="#58C7E2">-i</font> <font color="#58C7E2"><u style="text-decoration-style:solid">weld.npy</u></font> <font color="#58C7E2">-o</font> <font color="#58C7E2"><u style="text-decoration-style:solid">weld.exo</u></font> <font color="#58C7E2">--adapt</font>
<font color="#EC00FF"><b>    automesh 0.3.4</b></font>
     <font color="#58C7E2"><b>Reading</b></font> weld.npy
        <font color="#54E484"><b>Done</b></font> 4.392293ms [2 materials, 6,748,800 voxels]
     <font color="#58C7E2"><b>Meshing</b></font> adaptive hexahedra
        <font color="#54E484"><b>Done</b></font> 5.614659748s [1 blocks, 2,043,044 elements, 2,059,016 nodes]
     <font color="#58C7E2"><b>Writing</b></font> weld.exo
        <font color="#54E484"><b>Done</b></font> 181.983352ms
       <font color="#EC00FF"><b>Total</b></font> 5.801329s</pre>

![image](https://github.com/user-attachments/assets/776afaa0-d8e2-4c1b-b994-99a2dc445b8b)
![image](https://github.com/user-attachments/assets/bb2e615d-30d2-4764-9b1c-a4b68e20fc5c)
