### PR TITLE
link for .inp files in smoothing, clean up defeature

### DIFF
--- a/book/analysis/defeature/defeature.py
+++ b/book/analysis/defeature/defeature.py
@@ -1,5 +1,10 @@
-"""This module creates spheres and blobs inside of a domain for the purposes
+r"""This module creates spheres and blobs inside of a domain for the purposes
 of illustrating the defeature command.
+
+Example:
+source ~/autotwin/automesh/.venv/bin/activate
+cd ~/autotwin/automesh/book/analysis/defeature
+python defeature.py
 """
 
 import logging
@@ -78,19 +83,9 @@ def create_blob(data: np.ndarray, center: np.ndarray, radius_max: int) -> None:
     )
 
     # Create a random radius for each voxel based on a Gaussian distribution
-    # radius_variation = np.random.normal(
-    #     loc=radius_max, scale=radius_max * 0.2, size=data.shape
-    # )
-    # radius_variation = np.random.normal(
-    #     loc=radius_max, scale=radius_max * 0.0, size=data.shape
-    # )
-    # radius_variation = np.random.normal(
-    #     loc=radius_max, scale=radius_max * 0.2, size=data.shape
-    # )
     radius_variation = np.random.normal(
         loc=radius_max, scale=radius_max * 0.5, size=data.shape
     )
-    # breakpoint()
 
     # Set the voxels to 1 if they are within the radius variation
     data[distance <= radius_variation] = 1

--- a/book/development/README.md
+++ b/book/development/README.md
@@ -23,7 +23,7 @@
   * document:
     * `mdbook build`
        * output: automesh/book/build
-    * `mdbook serve`
+    * `mdbook serve --open`
       * interactive mode
       * on local machine, with Firefox, open the `index.html` file., e.g.,
       * `file:///Users/chovey/autotwin/automesh/book/build/index.html`

--- a/book/installation.md
+++ b/book/installation.md
@@ -111,8 +111,11 @@ pip --version
 On all environments, a [virtual environment](https://docs.python.org/3/tutorial/venv.html) is recommended, but not required.  Create a virtual environment:
 
 ```sh
-python3 -m venv .venv
+python3 -m venv .venv  # venv, or
+uv venv .venv          # using uv
 ```
+
+[`uv`](https://docs.astral.sh/uv/) is a fast PYthon package manager, written in Rust.  It is an alternative to `pip`.
 
 Activate the virtual environment:
 
@@ -151,7 +154,8 @@ cargo add automesh
 [![docs](https://img.shields.io/badge/Docs-API-8CA1AF?logo=readthedocs)](https://automesh.readthedocs.io)
 
 ```sh
-pip install automesh
+pip install automesh     # using pip, or
+uv pip install automesh  # using uv
 ```
 
 ## Step 3: Verify Installation

--- a/book/smoothing/taubin.md
+++ b/book/smoothing/taubin.md
@@ -3,7 +3,14 @@
 We examine the Taubin smoothing algorithm on a sphere composed of hexahedral elements.
 We created a two block (green inner volume, yellow outer volume) mesh in Cubit, then added normal noise to the hemisphere where the $x$ coordinate was positive.  We then applied Taubin smoothing to the noised model.
 
-The Cubit and Python code used to generate the noised input file and figures is included [below](#source).
+The Cubit and Python code used to generate the noised input file and figures is included [below](#source).  Alternatively, the `.inp` files can be downloaded directly from the table below:
+
+name | size (MB) | md5 checksum
+--- | :---: | :---:
+[`sphere_res_1cm.inp`](https://1drv.ms/u/c/3cc1bee5e2795295/ER8M2M-kE7BDsv6q6HqyqcIB7e1R5TcKhc-rZt4_Q4QXSg?e=Cxa6ef) | `1.5` | `644ef573c257222bfd61dcfda7131c6a`
+[`sphere_res_1cm_noised.inp`](https://1drv.ms/u/c/3cc1bee5e2795295/Eb-evDgLk-1GjUI-h-BjWE8B2boLnG5E8Adj5dfgtynCyw?e=u2kMWH) | `1.5` | `7031df475b972b15cf28bf2c5b69c162` 
+
+The two-material `sphere_res_1cm_noised.inp` file is visualized below with and without a midplane cut.
 
 iso | iso midplane | `xz` midplane
 :---: | :---: | :---:
@@ -25,15 +32,15 @@ We compare our volumetric results to the surface mesh presented by Taubin.[^Taub
 The smoothing parameters used were the `autotwin` defaults,[^autotwin_defaults] the same as used in Taubin's Figure 3 example.
 
 ```sh
-automesh smooth -i sphere_res_1cm_noised.inp -o s10.exo -n 10
+automesh smooth hex -i sphere_res_1cm_noised.inp -o s10.exo -n 10
 ```
 
 ```sh
-automesh smooth -i sphere_res_1cm_noised.inp -o s50.exo -n 50
+automesh smooth hex -i sphere_res_1cm_noised.inp -o s50.exo -n 50
 ```
 
 ```sh
-automesh smooth -i sphere_res_1cm_noised.inp -o s200.exo -n 200
+automesh smooth hex -i sphere_res_1cm_noised.inp -o s200.exo -n 200
 ```
 
 front | iso | `xz` midplane


### PR DESCRIPTION
* The `.inp` files for the smoothing section can now be downloaded directly.
* Some cleanup on the `defeature.py` script.