### PR TITLE
cli

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ macro_rules! about {
             format!(
                 "v{} build {} {} {}",
                 env!("CARGO_PKG_VERSION"),
-                var("GIT_COMMIT_HASH").unwrap(),
+                var("GIT_COMMIT_HASH").unwrap_or(env!("CARGO_PKG_VERSION").to_string()),
                 OS,
                 ARCH,
             ),


### PR DESCRIPTION
@hovey turns out the build number from commit hash does not work for any use of `cargo install` so I am adding a fallback to the version number. There is no good solution out there for this that I can find.