### PR TITLE
tree

### DIFF
--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -156,21 +156,14 @@ pub struct Cell {
 }
 
 impl Cell {
-    pub fn any_samples_inside(&self, samples: &[[u16; NSD]]) -> bool {
-        let x_min = *self.get_min_x();
-        let y_min = *self.get_min_y();
-        let z_min = *self.get_min_z();
-        let x_max = self.get_max_x();
-        let y_max = self.get_max_y();
-        let z_max = self.get_max_z();
-        samples.iter().any(|sample| {
-            sample[0] >= x_min
-                && sample[0] < x_max
-                && sample[1] >= y_min
-                && sample[1] < y_max
-                && sample[2] >= z_min
-                && sample[2] < z_max
-        })
+    pub fn any_samples_inside(&self, samples_map: &[Vec<Vec<bool>>]) -> bool {
+        let min_x = self.min_x as usize;
+        let min_y = self.min_y as usize;
+        let min_z = self.min_z as usize;
+        let max_x = (self.min_x + self.lngth) as usize;
+        let max_y = (self.min_y + self.lngth) as usize;
+        let max_z = (self.min_z + self.lngth) as usize;
+        (min_x..max_x).any(|i| (min_y..max_y).any(|j| (min_z..max_z).any(|k| samples_map[i][j][k])))
     }
     pub const fn get_block(&self) -> u8 {
         if let Some(block) = self.block {

--- a/src/tree/tessellation/mod.rs
+++ b/src/tree/tessellation/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     tree::{Cell, NUM_FACES, Octree, PADDING},
 };
 use conspire::math::{Scalar, Tensor, TensorArray};
+// use std::collections::HashSet;
 
 #[cfg(feature = "profile")]
 use std::time::Instant;
@@ -46,9 +47,18 @@ impl From<(TriangularFiniteElements, Size)> for OctreeAndSamples {
                     ]
                 })
                 .collect();
+            let (nel_x, nel_y, nel_z) = tree.nel().into();
+            let mut map = vec![vec![vec![false; nel_x]; nel_y]; nel_z];
+            // let mut outside = vec![vec![vec![false; nel_x]; nel_y]; nel_z];
+            // let mut visited = HashSet::new();
+            samples.iter().for_each(|&[i, j, k]| {
+                map[i as usize][j as usize][k as usize] = true;
+                // outside[i as usize][j as usize][k as usize] = true;
+                // visited.insert([i, j, k]);
+            });
             let mut index = 0;
             while index < tree.len() {
-                if tree[index].is_voxel() || !tree[index].any_samples_inside(&samples) {
+                if tree[index].is_voxel() || !tree[index].any_samples_inside(&map) {
                     tree[index].block = Some(block)
                 } else {
                     tree.subdivide(index)


### PR DESCRIPTION
octree initial construction by subdivision of cells containing STL nodes is essentially free now

before: a little over 8s (see #575)

after: about 70ms

<pre><font color="#58C7E0">cargo</font> <font color="#58C7E2">run</font> <font color="#58C7E2">-qr</font> <font color="#58C7E2">-F</font> <font color="#58C7E2">profile</font> <font color="#58C7E2">--</font> <font color="#58C7E2">mesh</font> <font color="#58C7E2">hex</font> <font color="#58C7E2">-i</font> <font color="#58C7E2"><u style="text-decoration-style:solid">bunny.stl</u></font> <font color="#58C7E2">-o</font> <font color="#58C7E2"><u style="text-decoration-style:solid">bunny.exo</u></font> <font color="#58C7E2">-s</font> <font color="#58C7E2">0.1</font>
<font color="#EC00FF"><b>    automesh 0.3.6</b></font>
     <font color="#58C7E2"><b>Reading</b></font> bunny.stl
        <font color="#54E484"><b>Done</b></font> 33.208486ms
     <font color="#58C7E2"><b>Meshing</b></font> adaptive hexahedra
             <font color="#E0B401"><b>Serializing triangles</b></font> 361.691µs
             <font color="#E0B401"><b>Node-element connectivity</b></font> 1.374563ms 
             <font color="#E0B401"><b>Node-node connectivity</b></font> 3.739414ms 
             <font color="#E0B401"><b>Splitting large edges</b></font> 172.674883ms
             <font color="#E0B401"><b>Octree initialization</b></font> 738.387µs
             <font color="#E0B401"><b>Subdivision from size</b></font> 67.221991ms
             <font color="#E0B401"><b>Balancing and pairing</b></font> 394.644619ms
             <font color="#E0B401"><b>Dualization of octree</b></font> 377.163696ms 
             <font color="#E0B401"><b>Marking outside nodes</b></font> 2.166565428s
             <font color="#E0B401"><b>Removing marked nodes</b></font> 62.442602ms
             <font color="#E0B401"><b>Show number of blocks</b></font> 210.947µs
        <font color="#54E484"><b>Done</b></font> 3.311555709s [1 blocks, 311057 elements, 377117 nodes]
     <font color="#58C7E2"><b>Writing</b></font> bunny.exo
             <font color="#E0B401"><b>Element-to-node connectivity</b></font> 6.760163ms
             <font color="#E0B401"><b>Nodal coordinates</b></font> 5.060925ms
        <font color="#54E484"><b>Done</b></font> 24.970619ms
       <font color="#EC00FF"><b>Total</b></font> 3.374535745s</pre>