### PR TITLE
Add readme field to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [project]
 authors = [
-  {email = "chovey@sandia.gov"},
-  {name = "Chad B. Hovey"},
-  {email = "mrbuche@sandia.gov"},
-  {name = "Michael R. Buche"},
+  {name = "Chad B. Hovey", email = "chovey@sandia.gov"},
+  {name = "Michael R. Buche", email = "mrbuche@sandia.gov"},
 ]
 classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
hopefully fix that PyPI.org is missing the README in recent releases