### PR TITLE
dualization

### DIFF
--- a/src/fem/mod.rs
+++ b/src/fem/mod.rs
@@ -826,7 +826,7 @@ impl From<(Tessellation, Size)> for HexahedralFiniteElements {
         let mut k;
         let mut index = 0;
         let mut indices = vec![[0, 0, 0]];
-        let lim = (tree.nel().x() - 2) as u16;
+        let lim = (tree.nel().x() - 1) as u16;
         while index < indices.len() {
             [i, j, k] = indices[index];
             if i > 0 && !samples[(i - 1) as usize][j as usize][k as usize] {


### PR DESCRIPTION
@hovey changing a 2 to a 1 was the answer. The grid was not wide enough in some cases and left a lot of the nodes on the +x, +y, +z faces of the original dualized mesh, which would make orphan nodes of course, but also extra elements I guess. Extended the binning to get those. I remember trying to choose -2 or -1 there a few weeks ago, made the wrong choice I guess!