### PR TITLE
Read ASCII or binary STL, write binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.4.3"
 
 [dependencies]
 clap = { version = "=4.6.6", features = ["derive"] }
-conspire = { version = "=0.7.2", features = ["geometry", "netcdf"] }
+conspire = { version = "=0.7.3", features = ["geometry", "netcdf"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "docs/katex.html"]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -2,7 +2,7 @@ use super::ErrorWrapper;
 use conspire::{
     geometry::{
         grid::{Input as GridInput, Output as GridOutput, Voxels},
-        mesh::{Input as MeshInput, Mesh, Output as MeshOutput, Tessellation, Vtk},
+        mesh::{Input as MeshInput, Mesh, Output as MeshOutput, Stl, Tessellation, Vtk},
     },
     io::{Write, write::Compression},
 };
@@ -78,7 +78,7 @@ pub fn write_mesh(file: &str, mesh: Mesh<3>, quiet: bool) -> Result<(), ErrorWra
         Some("vtu") => mesh.write(MeshOutput::Vtk(Vtk::UnstructuredGrid(Compression::Off(
             file,
         ))))?,
-        Some("stl") => Tessellation::from(mesh).write(file)?,
+        Some("stl") => Tessellation::from(mesh).write(Stl::Binary(file))?,
         _ => return Err(invalid_output(file, extension)),
     } // Output::Vtk(Vtk::UnstructuredGrid(Compression::Off(path)))
     crate::echo!(quiet, "        \x1b[1;92mDone\x1b[0m {:?}", time.elapsed());


### PR DESCRIPTION
Adopts the ASCII STL support from conspire (mrbuche/conspire.rs#148, released in 0.7.3).

- Bumps `conspire` to `=0.7.3`.
- STL reads now accept either encoding. `Tessellation::try_from(&Path)` keeps its signature and sniffs the encoding itself, so `read_mesh` and the two `mesh` subcommand call sites needed no changes.
- STL writes stay binary. Conspire replaced `Write<P> for Tessellation` with `Write<Stl<P>>`, so `write_mesh` now passes `Stl::Binary(file)`.

Both encodings use the `.stl` extension, so the extension dispatch and CLI help strings are unchanged.

Verified: round-tripping `tests/input/double.stl` yields a 1084-byte file (84 + 50 × 20 facets) with the zeroed 80-byte binary header, and a hand-written ASCII STL reads back and comes out as an 84 + 50 × 1 binary file. Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)