### PR TITLE
Doc interval

### DIFF
--- a/book/development.md
+++ b/book/development.md
@@ -29,6 +29,20 @@
     * [Python Debugger](https://marketplace.visualstudio.com/items?itemName=ms-python.debugpy)
     * [Rust Analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
 * [GitHub CLI](https://cli.github.com)
+* **`cargo bi` build+install helper** (macOS) — [`scripts/cargo-bi`](https://github.com/autotwin/automesh/blob/main/scripts/cargo-bi)
+  chains `cargo build` and `cargo install --path . --force` into one
+  command; see [Development Cycle Overview](#development-cycle-overview)
+  for why that matters.  Install it once, symlinked so future updates to
+  the script are picked up automatically:
+
+    ```sh
+    ln -s "$(pwd)/scripts/cargo-bi" ~/.cargo/bin/cargo-bi
+    ```
+
+    Cargo's plugin mechanism treats any executable named `cargo-*` on
+    `PATH` as the subcommand `cargo *`, so this makes `cargo bi` (and
+    `cargo bi --release`) available immediately, from any directory
+    containing a `Cargo.toml`.
 
 ## Clone Repository
 
@@ -66,6 +80,12 @@ so no `PATH` changes should be needed.
 * **Branch**
 * **Develop**
     * `cargo build`
+        * `cargo install --path . --force` — updates the `automesh` on
+          `PATH` (`~/.cargo/bin/automesh`).  `cargo build` alone only
+          writes to `target/`; plain `automesh` keeps resolving to
+          whatever was last installed until this is rerun.
+        * `cargo bi` (or `cargo bi --release`) runs both steps in one
+          command — see [Optional](#optional) for one-time setup.
     * Develop:
         * tests
         * implementation

--- a/scripts/cargo-bi
+++ b/scripts/cargo-bi
@@ -1,0 +1,12 @@
+#!/bin/sh
+# cargo bi [--release] [other cargo-build args...]
+# Builds the crate, then reinstalls its binary to ~/.cargo/bin so plain
+# invocations of the tool on PATH pick up the change. `cargo build` alone
+# only writes to target/ and never touches an existing `cargo install`.
+#
+# Cargo invokes external subcommands as `cargo-bi bi <rest...>`, passing
+# the subcommand name itself as $1 — shift it off before forwarding.
+set -e
+shift
+cargo build "$@"
+cargo install --path . --force

--- a/src/smooth/mod.rs
+++ b/src/smooth/mod.rs
@@ -5,7 +5,7 @@ use super::{
     remesh::{MeshRemeshSubcommand, apply_remesh_subcommand},
 };
 use clap::Subcommand;
-use conspire::geometry::mesh::{Mesh, Smoothing, Weighting};
+use conspire::geometry::mesh::{Connectivity, Mesh, Smoothing, Weighting};
 use std::time::Instant;
 
 pub const TAUBIN_DEFAULT_ITERS: usize = 20;
@@ -108,6 +108,17 @@ pub fn apply_smoothing_method(
     hierarchical: bool,
     quiet: bool,
 ) -> Result<(), ErrorWrapper> {
+    if mesh.connectivities().iter().any(|connectivity| {
+        matches!(
+            connectivity,
+            Connectivity::Polyhedral(_) | Connectivity::Polygonal(_)
+        )
+    }) {
+        return Err(ErrorWrapper::from(
+            "Smoothing is not yet implemented for polyhedral or polygonal connectivity \
+             (mesh hexdom/poly output)",
+        ));
+    }
     let time = Instant::now();
     let method = method.unwrap_or_else(|| "Taubin".to_string());
     let smoothing = match method.as_str() {

--- a/src/smooth/mod.rs
+++ b/src/smooth/mod.rs
@@ -5,7 +5,7 @@ use super::{
     remesh::{MeshRemeshSubcommand, apply_remesh_subcommand},
 };
 use clap::Subcommand;
-use conspire::geometry::mesh::{Connectivity, Mesh, Smoothing, Weighting};
+use conspire::geometry::mesh::{Mesh, Smoothing, Weighting};
 use std::time::Instant;
 
 pub const TAUBIN_DEFAULT_ITERS: usize = 20;
@@ -108,17 +108,6 @@ pub fn apply_smoothing_method(
     hierarchical: bool,
     quiet: bool,
 ) -> Result<(), ErrorWrapper> {
-    if mesh.connectivities().iter().any(|connectivity| {
-        matches!(
-            connectivity,
-            Connectivity::Polyhedral(_) | Connectivity::Polygonal(_)
-        )
-    }) {
-        return Err(ErrorWrapper::from(
-            "Smoothing is not yet implemented for polyhedral or polygonal connectivity \
-             (mesh hexdom/poly output)",
-        ));
-    }
     let time = Instant::now();
     let method = method.unwrap_or_else(|| "Taubin".to_string());
     let smoothing = match method.as_str() {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -162,6 +162,45 @@ fn mesh_uniform_rejects_a_segmentation_input() {
 }
 
 #[test]
+fn smooth_poly() {
+    let vtu = out("vtu");
+    run(&[
+        "mesh",
+        "poly",
+        "-i",
+        sphere().to_str().unwrap(),
+        "-o",
+        vtu.to_str().unwrap(),
+        "-s",
+        "5",
+    ]);
+    let output = out("vtu");
+    let metrics = out("csv");
+    run(&[
+        "smooth",
+        "-i",
+        vtu.to_str().unwrap(),
+        "-o",
+        output.to_str().unwrap(),
+        "-n",
+        "5",
+        "--metrics",
+        metrics.to_str().unwrap(),
+    ]);
+    assert_nonempty(&output);
+    // Polyhedra have no Verdict metrics, so every column is NaN rather than a panic.
+    let table = std::fs::read_to_string(&metrics).expect("metrics file was not created");
+    let mut rows = table.lines().skip(1).peekable();
+    assert!(rows.peek().is_some(), "metrics file has no rows");
+    rows.for_each(|row| {
+        assert!(
+            row.split(',').all(|value| value.trim() == "NaN"),
+            "expected all-NaN row, got {row:?}"
+        )
+    });
+}
+
+#[test]
 fn convert_mesh_exo_to_inp() {
     let exo = out("exo");
     run(&[


### PR DESCRIPTION
1. Helper script with documentation so that `cargo bi` does `build` and `install`, useful for developers wanting `automesh` to pick up the new targets, works with `cargo bi` and `cargo bi --release` as well.
2. A bit of a softer landing for users who might encounter smoothing API command on poly or hexdom.

Prefer @mrbuche  to approve item 2 in particular.

