### PR TITLE
Write Exodus (.exo) as netCDF-4 via conspire's pure-Rust HDF5 writer

### DIFF
--- a/.github/workflows/Book.yml
+++ b/.github/workflows/Book.yml
@@ -20,8 +20,6 @@ jobs:
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
         with:
           toolchain: stable
-      - name: netCDF
-        run: sudo apt-get update && sudo apt-get install -y libnetcdf-dev
       - name: Ansifilter
         run: sudo apt-get install -y ansifilter
       - name: mdBook

--- a/.github/workflows/Python.yml
+++ b/.github/workflows/Python.yml
@@ -20,8 +20,6 @@ jobs:
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
         with:
           toolchain: stable
-      - name: netCDF
-        run: sudo apt-get update && sudo apt-get install -y libnetcdf-dev
       - name: Python
         uses: actions/setup-python@v7
         with:
@@ -43,9 +41,6 @@ jobs:
       fail-fast: true
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        exclude:
-          # TODO: netCDF vcpkg install is broken on Windows runners; re-enable once fixed.
-          - os: windows-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v7
@@ -53,17 +48,6 @@ jobs:
       uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
       with:
         toolchain: stable
-    - name: netCDF
-      shell: bash
-      run: |
-        case "${{ runner.os }}" in
-          Linux) sudo apt-get update && sudo apt-get install -y libnetcdf-dev ;;
-          macOS) brew install netcdf ;;
-          Windows)
-            vcpkg install netcdf-c:x64-windows
-            echo "C:/vcpkg/installed/x64-windows/bin" >> "$GITHUB_PATH"
-            ;;
-        esac
     - name: Python
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/Rust.yml
+++ b/.github/workflows/Rust.yml
@@ -21,8 +21,6 @@ jobs:
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
         with:
           toolchain: stable
-      - name: netCDF
-        run: sudo apt-get update && sudo apt-get install -y libnetcdf-dev
       - name: Install
         run: cargo install cargo-llvm-cov
       - name: Coverage
@@ -32,8 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: netCDF
-        run: sudo apt-get update && sudo apt-get install -y libnetcdf-dev
       - name: Info
         run: sed -i "s/option_env!(\"GIT_COMMIT_HASH\").unwrap(),/\"$(git rev-parse --short HEAD)\".to_string(),/" src/main.rs
       - name: Package
@@ -52,9 +48,6 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         toolchain: [beta, stable]
-        exclude:
-          # TODO: netCDF vcpkg install is broken on Windows runners; re-enable once fixed.
-          - os: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -63,17 +56,6 @@ jobs:
         with:
           components: clippy, rustfmt
           toolchain: ${{ matrix.toolchain }}
-      - name: netCDF
-        shell: bash
-        run: |
-          case "${{ runner.os }}" in
-            Linux) sudo apt-get update && sudo apt-get install -y libnetcdf-dev ;;
-            macOS) brew install netcdf ;;
-            Windows)
-              vcpkg install netcdf-c:x64-windows
-              echo "C:/vcpkg/installed/x64-windows/bin" >> "$GITHUB_PATH"
-              ;;
-          esac
       - name: Build
         run: cargo build --release
       - name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ version = "0.4.6"
 
 [dependencies]
 clap = { version = "=4.6.6", features = ["derive"] }
-conspire = { version = "0.7.6", features = ["geometry", "netcdf"] }
+# TEMPORARY: pinned to conspire `main` for the homegrown netCDF-4 (HDF5) Exodus writer.
+conspire = { git = "https://github.com/mrbuche/conspire.rs", branch = "main", features = ["geometry"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "docs/katex.html"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ version = "0.4.6"
 
 [dependencies]
 clap = { version = "=4.6.6", features = ["derive"] }
-# TEMPORARY: pinned to conspire `main` for the homegrown netCDF-4 (HDF5) Exodus writer.
-conspire = { git = "https://github.com/mrbuche/conspire.rs", branch = "main", features = ["geometry"] }
+conspire = { version = "0.7.7", features = ["geometry"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "docs/katex.html"]

--- a/book/development.md
+++ b/book/development.md
@@ -17,10 +17,6 @@
     ```sh
     rustup update
     ```
-* [netCDF](https://www.unidata.ucar.edu/software/netcdf/), a system library
-  `automesh` links against for Exodus II I/O [^netcdf_2026] — see the
-  [netCDF Prerequisite](installation.md#netcdf-prerequisite) in Installation
-  for per-platform install commands.
 
 ## Optional
 
@@ -110,12 +106,3 @@ so no `PATH` changes should be needed.
     * Clean:
         * `cargo clean`
 * **Merge Request**
-
-## References
-
-[^netcdf_2026]: `automesh`'s build script looks for the netCDF library in a
-    fixed, OS-specific location (e.g. `/opt/homebrew/lib` or `/usr/local/lib`
-    on macOS, `/usr/lib/x86_64-linux-gnu` on Linux, or
-    `C:/vcpkg/installed/x64-windows/lib` on Windows) rather than using
-    `pkg-config` or an environment variable, so netCDF must be installed to
-    one of those default locations for the build to find it.

--- a/book/installation.md
+++ b/book/installation.md
@@ -24,11 +24,6 @@ route actually installs.
 
 For macOS and Linux, use a terminal.  For Windows, use a Command Prompt (CMD) or PowerShell.
 
-The Rust route links against a netCDF library already present on your
-system rather than building one — see
-[netCDF Prerequisite](#netcdf-prerequisite) below for how to install it on
-each platform.
-
 ## Step 1: Install Prerequisites
 
 * The Rust route depends on [Rust](https://www.rust-lang.org/) and [Cargo](https://doc.rust-lang.org/cargo/).
@@ -41,45 +36,6 @@ each platform.
 ### Rust Prerequisites
 
 It is recommended to install Rust using [Rustup](https://rust-lang.org/learn/get-started/), which is an installer and version management tool.
-
-#### netCDF Prerequisite
-
-`automesh` links against [netCDF](https://www.unidata.ucar.edu/software/netcdf/)
-rather than building it from source, so a netCDF library must already be on
-your system before `cargo install automesh` or `cargo build` will succeed.
-This applies to the Rust route, and to the Python route's source-distribution
-fallback (see [Step 2](#step-2-install-automesh)).
-
-Install it with your platform's package manager, the same way the project's
-own CI does (see
-[`.github/workflows/Rust.yml`](https://github.com/autotwin/automesh/blob/main/.github/workflows/Rust.yml)):
-
-##### macOS
-
-```sh
-brew install netcdf
-```
-
-##### Linux (Debian/Ubuntu)
-
-```sh
-sudo apt-get update && sudo apt-get install -y libnetcdf-dev
-```
-
-##### Windows
-
-```sh
-vcpkg install netcdf-c:x64-windows
-```
-
-Then add `C:\vcpkg\installed\x64-windows\bin` to your `PATH` so the netCDF
-DLL can be found at runtime.
-
-> **Note:** the Windows `vcpkg` install of netCDF is currently unreliable in
-> CI (see the `TODO` in `Rust.yml`), so the Windows build is not exercised
-> by continuous integration. If you hit trouble building on Windows, prefer
-> the [Python route](#python-install-a-prebuilt-binary-with-pip), which
-> installs a prebuilt binary and does not require a local netCDF install.
 
 ### Python Prerequisites
 
@@ -237,30 +193,6 @@ subprocess, exactly as you would a Cargo-installed copy:
 import subprocess
 
 subprocess.run(["automesh", "mesh", "hex", "-i", "in.npy", "-o", "out.exo", "-r", "0"])
-```
-
-## Troubleshooting
-
-### netCDF library not found
-
-`automesh`'s build script does not use `pkg-config` or an environment
-variable to locate netCDF — it checks a fixed, OS-specific location instead:
-
-| OS | expected location |
-| :--- | :--- |
-| macOS | `/opt/homebrew/lib` or `/usr/local/lib` |
-| Linux | `/usr/lib/x86_64-linux-gnu` |
-| Windows | `C:/vcpkg/installed/x64-windows/lib` |
-
-If `cargo install automesh` or `cargo build` fails with a "Could not find
-netCDF library" error, the library isn't installed in one of these
-locations. Reinstall netCDF with the package manager for your platform (see
-[netCDF Prerequisite](#netcdf-prerequisite)), which installs to the expected
-location by default, then retry:
-
-```bash
-cargo clean
-cargo build
 ```
 
 ## Environment Modules

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -2,7 +2,9 @@ use super::ErrorWrapper;
 use conspire::{
     geometry::{
         grid::{Input as GridInput, Output as GridOutput, Voxels},
-        mesh::{Input as MeshInput, Mesh, Output as MeshOutput, Stl, Tessellation, Vtk},
+        mesh::{
+            ExodusFormat, Input as MeshInput, Mesh, Output as MeshOutput, Stl, Tessellation, Vtk,
+        },
     },
     io::{Write, write::Compression},
 };
@@ -73,7 +75,10 @@ pub fn write_mesh(file: &str, mesh: Mesh<3>, quiet: bool) -> Result<(), ErrorWra
     let extension = extension(file);
     match extension {
         Some("inp") => mesh.write(MeshOutput::Abaqus(file))?,
-        Some("exo") => mesh.write(MeshOutput::Exodus(file))?,
+        Some("exo") => mesh.write(MeshOutput::Exodus(ExodusFormat::Netcdf4 {
+            path: file,
+            threads: std::thread::available_parallelism().map_or(1, |threads| threads.get()),
+        }))?,
         Some("mesh") => mesh.write(MeshOutput::Medit(file))?,
         Some("vtu") => mesh.write(MeshOutput::Vtk(Vtk::UnstructuredGrid(Compression::Off(
             file,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -61,6 +61,13 @@ fn mesh_hex_to_exo() {
         output.to_str().unwrap(),
     ]);
     assert_nonempty(&output);
+    // Exodus output is the netCDF-4 (HDF5) container: expect the HDF5 magic.
+    let bytes = std::fs::read(&output).expect("output file was not created");
+    assert_eq!(
+        &bytes[..8],
+        b"\x89HDF\r\n\x1a\n",
+        "expected a netCDF-4 (HDF5) Exodus file"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

conspire replaced the C netCDF FFI with a homegrown pure-Rust implementation that now includes a tier-1 **netCDF-4 (HDF5)** writer — chunked, shuffle + deflate, parallel chunk compression. This wires automesh up to it (conspire 0.7.7).

- **`Cargo.toml`** — bump to conspire 0.7.7; drop the `netcdf` feature (no longer exists; conspire has zero deps and no build script now).
- **`src/io/mod.rs`** — `write_mesh` writes every `.exo` as `ExodusFormat::Netcdf4 { path, threads }` with `threads = available_parallelism()`. No CLI flag, no classic option from the CLI. Reads are untouched — `NetCDF::open` sniffs the magic bytes and handles classic + netCDF-4 transparently.
- **`tests/cli.rs`** — `mesh_hex_to_exo` also asserts the HDF5 magic (`\x89HDF\r\n\x1a\n`).
- **CI + book** — no system netCDF library anywhere anymore, so every `libnetcdf-dev` / `brew install netcdf` / `vcpkg install netcdf-c` step is gone from `Rust.yml`, `Python.yml`, `Book.yml`, and the `windows-latest` matrix rows that were excluded *solely* because the vcpkg netCDF install was flaky are re-enabled. Book prerequisite / troubleshooting sections that referenced the system library are removed.

## Verification

- `cargo build` / `cargo test --release` — all green (17 CLI + unit tests)
- `cargo fmt --check`, `cargo clippy --tests` — clean
- Reference libnetcdf `ncdump -k out.exo` → `netCDF-4`; `ncdump -h` parses the full Exodus header (`connect{N}` with `elem_type=hex8`, coords, `eb_prop1`, global attrs)
- Round-tripped `.exo → .vtu`, `.exo → .inp`, `metrics -i out.exo`

## Notes

- For tiny meshes the HDF5 container overhead makes files larger than classic (the letter-F test mesh is ~18 KB); deflate wins on real-size meshes.
- Windows CI runs for the first time in a while — watch for non-netCDF Windows issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
